### PR TITLE
docs: reconcile claims with reality + build-vs-buy plan (PR A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Docs
+
+* Add `docs/MODERNIZATION_PLAN.md` and `docs/adr/0004-build-vs-buy.md` sequencing the 2026 level-up (real vector RAG, native structured outputs, LiteLLM cost, LangGraph agent, optional MCP) as small per-PR changes with a build-vs-buy rationale per component.
+* Reconcile the README roadmap to reality (no behavior change): the LangGraph architect mode is **planned**, not shipped; RAG ships a keyword/deterministic baseline; the architect is a structured chain; and the LLM runs in a deterministic offline stub unless a provider key is set.
+
 ## [0.9.0] - 2025-10-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@
 ![Hero](docs/images/hero.png)
 
 ## Why AI Architect
-**AI Architect** demonstrates how to build LLM-driven systems with **governance, observability, and FinOps** built-in. It merges **RAG**, **agentic workflows**, and **MLflow** into a production-grade reference architecture.
+**AI Architect** demonstrates how to build LLM-driven systems with **governance, observability, and FinOps** built-in. It brings **retrieval**, **orchestration**, and **MLflow** together into a locally-runnable reference architecture (a demonstrator, not a hardened product). See [docs/MODERNIZATION_PLAN.md](docs/MODERNIZATION_PLAN.md) for what is shipped vs in progress.
 
 - **Transparent** by design — audit logs, hashed request/response pairs.
 - **Observable** — Prometheus `/metrics` + Grafana dashboards.
-- **Cost-aware** — token and cost tracking per user/day.
+- **Cost-aware** — per-request token accounting and FinOps metrics (real per-model $ cost via LiteLLM is on the roadmap).
 - **Governed** — RBAC, retention sweeps, and prompt registries.
+
+> **Project status (honest):** a working demonstrator, not a hardened product. Out of the box the LLM runs in a deterministic offline **stub** unless a provider key is set; RAG ships a **keyword/deterministic baseline** (vector retrieval is on the roadmap); the architect is a structured **chain** (a LangGraph agent is planned). What is shipped vs in progress lives in [docs/MODERNIZATION_PLAN.md](docs/MODERNIZATION_PLAN.md).
 
 ---
 
@@ -179,12 +181,14 @@ Full details → `docs/observability.md`, `docs/security.md`
 ## 🗺️ Roadmap (Condensed)
 | Phase | Focus | Status |
 |-------|--------|--------|
-| 0–2 | Core APIs, RAG, Audit, Metrics | ✅ Done |
-| 3–4 | Agents, RBAC, Grafana, Deploy Recipes | ✅ Done |
+| 0–2 | Core APIs, RAG (keyword baseline), Audit, Metrics | ✅ Done |
+| 3–4 | Orchestration (chain), RBAC, Grafana, Deploy Recipes | ✅ Done |
 | 5–6 | PII detection, Risk ML integration, Router v2 | 🚧 In Progress |
-| 7–8 | Memory & Advanced Agents | ✅ Done |
-| 9 | Architect deterministic mode (LangGraph) | ✅ Done |
-| 10+ | New sub-agents (FinOps, Drift Monitor, Router Preview) | 🧩 Planned |
+| 7–8 | Memory (short + long term) | ✅ Done |
+| 9 | Architect agent on LangGraph | 🧩 Planned |
+| 10+ | Real vector RAG, LiteLLM cost tracking, MCP surface | 🧩 Planned |
+
+> Roadmap and build-vs-buy rationale: [docs/MODERNIZATION_PLAN.md](docs/MODERNIZATION_PLAN.md), [ADR-0004](docs/adr/0004-build-vs-buy.md).
 
 ---
 

--- a/docs/MODERNIZATION_PLAN.md
+++ b/docs/MODERNIZATION_PLAN.md
@@ -1,0 +1,57 @@
+# Modernization Plan
+
+This repo was first written in late 2025 while learning the LLM/agent stack. A
+lot of capability was hand-rolled rather than pulled from a framework. That was a
+deliberate learning choice and, in several places, remains the right call. This
+plan records where hand-rolled stays (documented as a build-vs-buy decision) and
+where a library genuinely earns its place, and sequences the work into small,
+reviewable PRs.
+
+See [ADR-0004: Build-vs-buy policy](adr/0004-build-vs-buy.md) for the per-component
+rationale, and [ADR-0001: Ports-and-Adapters](adr/0001-ports-and-adapters.md) for the
+seam these changes slot into (real adapters filling existing ports).
+
+## Principles
+
+- **Match claims to code first.** No feature is described as shipped until the
+  code does it. Honesty PR (A) lands before the up-levels.
+- **Adopt a library only when the hand-rolled version is worse on a real axis**
+  (a false claim, a reliability liability, or an unmet capability), not for
+  fashion. Modernizing here mostly *reduces* framework coupling.
+- **One short-lived branch per PR off `main`,** merged when CI is green. Each PR
+  is independently valuable and revertible.
+- **Every PR carries its docs:** an ADR for any decision, updates to the relevant
+  `docs/*.md`, and a `CHANGELOG.md` entry.
+
+## Locked decisions
+
+- **Agent (PR F): build a real LangGraph agent.** The architect is currently a
+  linear chain. Rather than rename it, we implement a genuine tool-loop agent on
+  LangGraph, which also retires the (previously false) "LangGraph" roadmap claim
+  by actually delivering it.
+- **LangChain (PR D): drop it, keep only `langchain-core`.** The pinned
+  `langchain==0.1.11` is load-bearing in exactly the spots being modernized
+  (a dead `langchain.schema` import, and a "RAG" module that imports no
+  langchain). Native structured outputs remove the need for the heavyweight
+  package; `langchain-core` stays only for typed output parsers.
+
+## PR sequence
+
+| # | Branch | Scope | Docs | Size | Depends on |
+|---|--------|-------|------|------|------------|
+| A | `docs/honesty-and-adrs` | Reconcile README/roadmap to reality; this plan; build-vs-buy ADR. No code behavior change. | ADR-0004, README | S | — |
+| B | `refactor/rag-honest-naming` | Rename `langchain_rag.py` → `doc_retriever.py`; remove the hardcoded stub-answer string and the fake HyDE/multi-query labels. | rag.md | S | A |
+| C | `feat/vector-rag` | Real embeddings (sentence-transformers) + Chroma retrieval behind `RAG_BACKEND`; keep deterministic baseline as fallback; wire `ingest_docs.py`; golden-query tests. | rag.md, rag_vector_backends.md | L | B |
+| D | `refactor/structured-outputs` | Replace `parse_json_safe` with native structured outputs / tool-use; delete dead `langchain.schema` import; drop `langchain` to `langchain-core`. | ADR | M | — |
+| E | `feat/litellm-client` | Swap the hand-rolled multi-provider client for LiteLLM (keep the `stub` provider); populate real `cost_usd` so FinOps metrics stop being 0.0. | observability.md | M | — |
+| F | `feat/langgraph-architect` | Real LangGraph tool-loop agent behind `AGENT_BACKEND`; deterministic builtin planner stays the default. | ADR, agents.md | L | C, D |
+| G | `feat/mcp-server` | Expose the tools/architect over MCP. High "2026-current" signal. | ADR, README | M–L | C, E |
+| H | `feat/pii-presidio` | Presidio detector behind a flag; regex baseline kept. | ADR | M | — |
+| I | `ci/coverage-gate` | Add the coverage gate the codecov badge implies (or drop the badge); run new tests. | — | S | — |
+
+**Recommended order:** A → B → C → D → E → F, then optional G / H / I.
+
+## Status legend
+
+✅ shipped and true · 🚧 in progress · 🧩 planned. This file is the source of
+truth for what those mean per component; individual docs link back here.

--- a/docs/adr/0004-build-vs-buy.md
+++ b/docs/adr/0004-build-vs-buy.md
@@ -1,0 +1,81 @@
+# ADR 0004: Build-vs-buy policy for AI-Architect components
+
+Date: 2026-07-01
+
+Status: Accepted
+
+Context
+- Much of this repo was hand-rolled in late 2025 while learning the LLM/agent
+  stack, rather than adopting a framework. Reviewing it in 2026, the question is
+  not "hand-rolled vs library" in the abstract, but per component: does the
+  custom implementation cost us anything real, or is it the better call?
+- A custom implementation is read two ways by a reviewer: "reinvented the wheel"
+  or "understood the primitives and made a deliberate call." The difference is a
+  documented decision plus the code actually being good. This ADR is that
+  documentation. It builds on the ports in [ADR-0001](0001-ports-and-adapters.md):
+  most changes fill a real adapter behind an existing port.
+
+Decision
+Classify each component into keep (hand-rolled, on purpose), adopt (a library
+earns its place), or decide (depends on ambition). Rationale is the axis on which
+the current code is measured, not fashion.
+
+- **Keep (hand-rolled is right; document, do not replace):**
+  - `router.py` — keyword/rule intent routing for a bounded intent set:
+    deterministic, zero-latency, zero-token, testable. An LLM router would add
+    cost and nondeterminism for no gain. Keep; optionally add an `llm` backend
+    behind the existing `ROUTER_BACKEND` switch.
+  - `app/utils/*` audit, RBAC, cost, retention — app-specific, no dominant
+    library; these are the project's differentiators. Owning them is correct.
+  - `rag_retriever.py` embeddings shim (stub / local / OpenAI) — a small, clean
+    abstraction behind `EmbeddingsPort`. Keep.
+  - prompt registry (`render_prompt` + `prompts/*.yaml`) — simple, versioned.
+    A prompt-management library adds little at this scope.
+  - `mlflow_client.py` — already a library (MLflow). Correct.
+
+- **Adopt (custom version is worse on a real axis):**
+  - LLM client (`llm_client.py`) → **LiteLLM** (hybrid: keep the `stub`
+    provider). The hand-rolled client hardcodes `cost_usd: 0.0` in every branch,
+    which guts the project's own FinOps claim. LiteLLM provides real per-model
+    cost, fallbacks, and 100+ providers. (PR E.)
+  - Output parsing (`prompt_runner.parse_json_safe`) → **native structured
+    outputs / tool-use**. ~150 lines of defensive JSON scraping is exactly what
+    provider-native structured output solves; it also removes the dead
+    `langchain.schema` import that pins us to `langchain==0.1.11`. (PR D.)
+  - Doc RAG (`langchain_rag.py`) → **real vector retrieval**. Despite the name it
+    imports no langchain and returns a hardcoded stub answer; the flagship
+    feature is hollow. Chroma + sentence-transformers are already dependencies.
+    (PRs B, C.)
+
+- **Decide by ambition:**
+  - The "architect agent" (`architect_agent.py`) is a linear chain, not an agent
+    (no tool loop). Decision: **build a real LangGraph agent** behind
+    `AGENT_BACKEND` rather than rename it a chain, delivering the capability the
+    roadmap previously claimed. (PR F.)
+
+Consequences
+- Modernizing here *reduces* framework coupling: PR D lets us drop the
+  heavyweight `langchain` package down to `langchain-core`.
+- The deterministic Null-Object defaults from ADR-0001 remain the CI/offline
+  path; adopted libraries sit behind ports and env flags, not in the hot path by
+  default.
+- Claims and code converge: PR A removes the overstated roadmap entries; PRs
+  C/E/F make the corresponding features real, then the roadmap is updated to
+  "shipped" truthfully.
+
+Alternatives considered
+- Blanket "adopt frameworks to shrink the code": rejected. It is what pinned us
+  to a stale `langchain` in the first place, and would replace defensible custom
+  code (router, audit) with coupling for no benefit.
+- Blanket "keep everything hand-rolled": rejected. It leaves the FinOps claim
+  false (cost=0), the RAG hollow, and the parser fragile.
+
+Implementation notes
+- Sequenced in [docs/MODERNIZATION_PLAN.md](../MODERNIZATION_PLAN.md) as PRs A–I.
+- Order: honesty (A) → RAG rename/real (B, C) → structured outputs (D) → LiteLLM
+  (E) → LangGraph agent (F) → optional MCP (G), Presidio (H), CI gate (I).
+
+References
+- docs/MODERNIZATION_PLAN.md
+- docs/adr/0001-ports-and-adapters.md
+- docs/rag.md, docs/agents.md, docs/observability.md


### PR DESCRIPTION
## What
Documentation + honesty pass, PR **A** of the modernization sequence. **No code behavior change.**

## Why
Before the up-level PRs (real vector RAG, native structured outputs, LiteLLM cost, LangGraph agent) land, the README should match the code. Today it marks a LangGraph architect mode as "✅ Done" though nothing imports `langgraph`, and presents the keyword-RAG / chain / stub-by-default reality as a finished product. Claims > code is the one thing a reviewer punishes hardest, so it goes first.

## Changes
- **README**: roadmap corrected (LangGraph → Planned; RAG labeled keyword baseline; orchestration labeled chain; memory scope trimmed); added an honest **Project status** note; softened "production-grade" → "demonstrator"; cost bullet clarified (real per-model $ cost via LiteLLM is roadmap).
- **docs/MODERNIZATION_PLAN.md** (new): the A–I PR sequence, branch/doc conventions, and two locked decisions — build a real **LangGraph** agent (F), and **drop `langchain` to `langchain-core`** (D).
- **docs/adr/0004-build-vs-buy.md** (new): per-component **keep / adopt / decide** rationale, building on ADR-0001's ports-and-adapters.
- **CHANGELOG**: `Unreleased` / Docs entry.

## Note
`docs/capabilities_current.md` was already honest (it scopes MCP, vector DB, and LangGraph-style features under "out of scope / to design next"), so the overstatement was isolated to the README marketing roadmap.

## Next
PR B `refactor/rag-honest-naming` → PR C `feat/vector-rag` → D → E → F, per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
