### PR TITLE
refactor: rename langchain_rag to doc_retriever (plan row B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+* Rename `app/services/langchain_rag.py` → `app/services/doc_retriever.py`; the module is a deterministic keyword-scan retriever and never used LangChain (`docs/adr/0005-doc-retriever-naming.md`).
+* Retire placeholder response paths: grounded `/query` answers are now extractive (built from matched snippets) instead of a hardcoded stub sentence; the fabricated `synthetic` citation fallback is removed; `audit.rag_backend` reports `keyword_scan`.
+* Rewrite `docs/rag.md` to describe the retrieval path that actually exists; the vector backend remains planned work (plan row C).
+
 ### Docs
 
 * Add `docs/MODERNIZATION_PLAN.md` and `docs/adr/0004-build-vs-buy.md`, sequencing the 2026 modernization (real vector retrieval, native structured outputs, LiteLLM cost tracking, LangGraph agent, optional MCP) as small per-PR changes with a build-vs-buy rationale per component.

--- a/app/routers/architect.py
+++ b/app/routers/architect.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from app.routers.query import Citation
-from app.services.langchain_rag import answer_with_citations
+from app.services.doc_retriever import answer_with_citations
 from app.services.architect_agent import run_architect_agent
 from app.utils.rbac import is_allowed_grounded_query, parse_role
 from app.utils.prompts import load_prompt

--- a/app/routers/pii.py
+++ b/app/routers/pii.py
@@ -51,7 +51,7 @@ def post_pii(req: Request, payload: PiiRequest):
     # Optional RAG citations for policy references
     if payload.grounded:
         try:
-            from app.services.langchain_rag import answer_with_citations
+            from app.services.doc_retriever import answer_with_citations
 
             resp = answer_with_citations("PII policy references", k=3)
             _ = resp.get("citations", [])

--- a/app/routers/query.py
+++ b/app/routers/query.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
-# legacy RAGRetriever removed; using LangChain-only path
+# legacy RAGRetriever removed; using the keyword-scan doc_retriever
 from app.utils.rbac import is_allowed_grounded_query, parse_role
 from db.session import get_session
 
@@ -86,7 +86,7 @@ def post_query(req: Request, payload: QueryRequest):
 
     # Initialize citations and backend marker
     citations: List[Citation] = []
-    rag_backend = "langchain"
+    rag_backend = "keyword_scan"
     # Initialize answer early; branches may set it. Fallback applied later if still empty.
     answer: str = ""
 
@@ -127,83 +127,17 @@ def post_query(req: Request, payload: QueryRequest):
             raise HTTPException(
                 status_code=403, detail="grounded query not allowed for this role"
             )
-        # LangChain-only RetrievalQA path
+        # Deterministic keyword-scan retrieval; the retriever handles its own
+        # filename-match / first-file fallbacks, so no safety net is needed here.
         try:
-            from app.services.langchain_rag import answer_with_citations
+            from app.services.doc_retriever import answer_with_citations
 
             # Ensure DOCS_PATH exists; if not, point to examples
             docs_path = os.getenv("DOCS_PATH") or "./examples"
             os.environ["DOCS_PATH"] = docs_path
             result = answer_with_citations(payload.question, k=3)
             citations = [Citation(**c) for c in result.get("citations", [])]
-            # Final safety net: ensure at least one citation for grounded QA
-            if not citations:
-                docs_path = os.getenv("DOCS_PATH", "./examples")
-                # try filename match
-                try:
-                    terms = [
-                        t.strip(".,:;!?()[]{}\"'`").lower()
-                        for t in payload.question.split()
-                    ]
-                    chosen = None
-                    if os.path.isdir(docs_path):
-                        for root, _, files in os.walk(docs_path):
-                            for fn in files:
-                                fn_low = fn.lower()
-                                if any(t and t in fn_low for t in terms):
-                                    chosen = os.path.join(root, fn)
-                                    break
-                            if chosen:
-                                break
-                        if not chosen:
-                            for root, _, files in os.walk(docs_path):
-                                text_files = [
-                                    f
-                                    for f in files
-                                    if f.lower().endswith((".txt", ".md"))
-                                ]
-                                search_list = text_files if text_files else files
-                                for fn in search_list:
-                                    p = os.path.join(root, fn)
-                                    if os.path.isfile(p):
-                                        chosen = p
-                                        break
-                                if chosen:
-                                    break
-                    if chosen:
-                        try:
-                            with open(
-                                chosen, "r", encoding="utf-8", errors="ignore"
-                            ) as f:
-                                text = f.read()
-                        except Exception:
-                            text = ""
-                        citations = [
-                            Citation(
-                                source=os.path.relpath(chosen, docs_path),
-                                page=None,
-                                snippet=(
-                                    text[:200] if isinstance(text, str) else ""
-                                ).replace("\n", " "),
-                            )
-                        ]
-                    else:
-                        # synth fallback
-                        citations = [
-                            Citation(
-                                source="synthetic",
-                                page=None,
-                                snippet=f"Synthetic context for: {payload.question}",
-                            )
-                        ]
-                except Exception:
-                    citations = [
-                        Citation(
-                            source="synthetic",
-                            page=None,
-                            snippet=f"Synthetic context for: {payload.question}",
-                        )
-                    ]
+            answer = result.get("answer") or ""
             # stash result flags to propagate later (after audit_dict exists)
             rag_flags = {
                 k: result[k]
@@ -254,9 +188,9 @@ def post_query(req: Request, payload: QueryRequest):
         llm_tokens_completion = pr.get("tokens_completion") or pr.get("llm_tokens_completion")
         llm_cost_usd = pr.get("cost_usd") or pr.get("llm_cost_usd")
 
-    # Stub answer baseline; branches may override earlier (e.g., pii_detect)
+    # Fallback when no branch produced an answer (LLM disabled, ungrounded query)
     if not answer:
-        answer = "This is a stubbed answer. In Phase 1, RAG provides citations from local docs."
+        answer = "No answer generated: LLM synthesis is disabled and the query was not grounded."
     # Ensure a single long sentence to trigger long-memory ingestion when enabled
     try:
         if long_enabled:

--- a/app/services/architect_agent.py
+++ b/app/services/architect_agent.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Tuple
 from langchain_core.output_parsers import PydanticOutputParser
 from app.services.llm_client import LLMClient
 from app.services.architect_schema import ArchitectPlan
-from app.services.langchain_rag import answer_with_citations
+from app.services.doc_retriever import answer_with_citations
 
 # Optional LangSmith tracing (env-gated)
 from app.utils.logger import get_logger as _get_logger

--- a/app/services/doc_retriever.py
+++ b/app/services/doc_retriever.py
@@ -1,13 +1,18 @@
+"""Deterministic keyword-scan document retriever.
+
+Scans text files under DOCS_PATH, scores them by keyword overlap with the
+question, and returns snippet citations. There are no embeddings, no vector
+store, and no LLM calls; results are fully deterministic, which keeps tests
+and CI reproducible. A real vector-retrieval backend is planned separately
+(see docs/MODERNIZATION_PLAN.md, row C).
+"""
+
 import os
 from typing import Any, Dict, List, Tuple
 
-# This module provides a LangChain RetrievalQA path behind a feature flag.
-# It is safe to import even if langchain is not installed because imports
-# are wrapped inside functions and guarded by the env flag.
-
 
 def is_enabled() -> bool:
-    # LC is always enabled as the sole backend
+    # keyword scan is currently the sole retrieval backend
     return True
 
 
@@ -141,10 +146,11 @@ def _merge_citations(
 
 
 def answer_with_citations(question: str, k: int = 3) -> Dict[str, Any]:
-    """Return an answer and citations using a LangChain RetrievalQA pipeline.
+    """Return citations from a deterministic keyword scan of DOCS_PATH.
 
-    Falls back to a lightweight deterministic response if LangChain is missing
-    or any error occurs, to keep tests stable.
+    The answer is extractive: it is composed from the top-ranked snippets.
+    When nothing matches, citations are empty and the answer says so; no
+    placeholder content is fabricated.
     """
     docs_path = os.getenv("DOCS_PATH", "./examples")
 
@@ -227,20 +233,18 @@ def answer_with_citations(question: str, k: int = 3) -> Dict[str, Any]:
                     "snippet": snippet,
                 }
             ]
-    # As a last resort, synthesize a citation from code to ensure at least one
-    if not citations:
-        try:
-            hy = hyde_snippet(question)
-        except Exception:
-            hy = f"Synthetic context for: {question}"
-        citations = [
-            {
-                "source": "synthetic",
-                "page": None,
-                "snippet": hy[:200].replace("\n", " "),
-            }
-        ]
-    answer = (
-        "This is a stubbed answer. In Phase 4, RAG provides citations from local docs."
-    )
+    if citations:
+        parts = []
+        for c in citations[:k]:
+            src = c.get("source", "unknown")
+            snippet = (c.get("snippet") or "").strip()
+            if snippet:
+                parts.append(f"[{src}] {snippet}")
+        answer = (
+            "Extracted from matching documents:\n" + "\n".join(parts)
+            if parts
+            else "Matching documents found; see citations."
+        )
+    else:
+        answer = f"No documents under {docs_path} matched the question."
     return {"answer": answer, "citations": citations, **meta}

--- a/app/services/pii_remediation.py
+++ b/app/services/pii_remediation.py
@@ -41,7 +41,7 @@ def _retrieve_guidance(query: str, k: int = 2) -> List[Dict[str, Any]]:
     # provider preserved for future selection; no-op for now to avoid unused warning
     os.getenv("EMBEDDINGS_PROVIDER", os.getenv("LLM_PROVIDER", "local"))
     try:
-        from app.services.langchain_rag import answer_with_citations
+        from app.services.doc_retriever import answer_with_citations
 
         resp = answer_with_citations(query, k=k)
         return resp.get("citations", [])

--- a/app/services/policy_navigator.py
+++ b/app/services/policy_navigator.py
@@ -22,9 +22,9 @@ def decompose(question: str, max_subqs: int | None = None) -> List[str]:
 
 
 def retrieve(subq: str, k: int = 3) -> List[Dict[str, Any]]:
-    # Use LC-backed retrieval wrapper
+    # Use the keyword-scan retriever
     try:
-        from app.services.langchain_rag import answer_with_citations
+        from app.services.doc_retriever import answer_with_citations
 
         resp = answer_with_citations(subq, k=k)
         return resp.get("citations", [])

--- a/docs/adr/0004-build-vs-buy.md
+++ b/docs/adr/0004-build-vs-buy.md
@@ -50,7 +50,7 @@ which the current code is measured, not fashion.
     outputs / tool-use**. ~150 lines of defensive JSON scraping is exactly
     what provider-native structured output solves; it also lets us drop the
     stale `langchain==0.1.11` pin down to `langchain-core`. (PR D.)
-  - Doc retrieval (`langchain_rag.py`) → **real vector retrieval**. The
+  - Doc retrieval (`doc_retriever.py`, formerly `langchain_rag.py`) → **real vector retrieval**. The
     current implementation is a deterministic keyword baseline; Chroma +
     sentence-transformers are already dependencies, so the vector path is the
     natural next step. The module is renamed to match what it does. (PRs B, C.)

--- a/docs/adr/0005-doc-retriever-naming.md
+++ b/docs/adr/0005-doc-retriever-naming.md
@@ -1,0 +1,41 @@
+# ADR 0005: Rename langchain_rag to doc_retriever; retire placeholder responses
+
+Date: 2026-07-04
+
+Status: Accepted
+
+Context
+- `app/services/langchain_rag.py` did not use LangChain. It was (and remains)
+  a deterministic keyword/file scan over `DOCS_PATH` that returns snippet
+  citations. The module name, its docstrings, and `docs/rag.md` all described
+  a LangChain RetrievalQA / Chroma vector path that does not exist in the
+  code (`LC_RAG_BACKEND` and `VECTORSTORE_PATH` were documented but read
+  nowhere). Names that overstate capability are the most expensive kind of
+  debt in a reference repo: reviewers find them fast, and they undermine the
+  parts that are genuinely built.
+- The retrieval path also fabricated output: `answer_with_citations` always
+  returned a hardcoded "This is a stubbed answer..." string, and when no
+  document matched it invented a `source: synthetic` citation. The `/query`
+  router duplicated that fabrication in a second safety-net block.
+
+Decision
+- Rename `app/services/langchain_rag.py` to `app/services/doc_retriever.py`
+  and describe it as what it is: a deterministic keyword-scan retriever.
+- Retire the placeholder response paths:
+  - The answer is now extractive, composed from the top-ranked snippets; when
+    nothing matches, citations are empty and the answer states that.
+  - The fabricated `synthetic` citation fallback is removed from both the
+    module and the `/query` router (the module's real-file fallbacks remain).
+  - The audit field `rag_backend` now reports `keyword_scan` instead of
+    `langchain`.
+- Rewrite `docs/rag.md` to document only what exists, pointing to
+  MODERNIZATION_PLAN row C for the real vector backend.
+
+Consequences
+- API-visible changes: `/query` grounded answers contain extracted snippets
+  instead of the stub sentence; `audit.rag_backend` changes value; queries
+  with an empty/missing corpus return zero citations instead of a fabricated
+  one. Callers that only consume `citations` (architect, PII remediation,
+  policy navigator) are unaffected.
+- Row C (`feat/vector-rag`) can now introduce a real vector backend behind
+  `RAG_BACKEND` without inheriting a misleading module name.

--- a/docs/capabilities_current.md
+++ b/docs/capabilities_current.md
@@ -40,7 +40,7 @@ Endpoints and behaviors
   - Flags: RISK_ML_ENABLED, RISK_THRESHOLD
 
 RAG (grounding) baseline
-- Implementation: app/services/langchain_rag.py
+- Implementation: app/services/doc_retriever.py
   - Deterministic local-docs scanning; honors flags:
     - RAG_MULTI_QUERY_ENABLED (with RAG_MULTI_QUERY_COUNT)
     - RAG_HYDE_ENABLED

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -10,7 +10,7 @@ Operational notes
 Repository map (high level)
 - FastAPI app: app/
   - Routers: app/routers/* (query, research, predict, pii, pii_remediation, risk, memory, metrics, architect, architect_stream, architect_ui, policy)
-  - Services: app/services/* (langchain_rag, router, llm_client, policy_navigator, architect_agent, architect_schema, pii_detector, pii_remediation, mlflow_client, prompt_runner)
+  - Services: app/services/* (doc_retriever, router, llm_client, policy_navigator, architect_agent, architect_schema, pii_detector, pii_remediation, mlflow_client, prompt_runner)
   - Utils: app/utils/* (logger, metrics, audit, rbac, cost, prompts, exceptions, retention)
   - Memory backends: app/memory/* (short_memory, long_memory)
   - Schemas: app/schemas/* (research, predict)

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,7 +1,7 @@
 # Component map
 
 - app/routers/query.py: core /query with router integration and RAG wiring
-- app/services/langchain_rag.py: retrieval/citations and RAG flags propagation
+- app/services/doc_retriever.py: retrieval/citations and RAG flags propagation
 - app/services/router.py: rules v2 backend, ENV-configurable
 - app/routers/pii.py, app/services/pii_detector.py: PII detection logic and endpoint
 - app/routers/risk.py, app/services/risk_scorer.py: Risk endpoint and heuristic scorer

--- a/docs/ports_and_adapters.md
+++ b/docs/ports_and_adapters.md
@@ -93,7 +93,7 @@ Backward compatibility and fallbacks
 - Tests/CI always pass without network/API keys.
 
 Mapping to current code
-- RAG today: app/services/langchain_rag.py provides answer_with_citations with deterministic behavior and feature flags (multi-query, HyDE). This will become a façade over RAGPort.
+- RAG today: app/services/doc_retriever.py provides answer_with_citations with deterministic behavior and feature flags (multi-query, HyDE). This will become a façade over RAGPort.
 - Query and Architect routes already accept grounded mode and emit citations; they will keep working after we swap the underlying adapter.
 - LLM calls: app/services/llm_client.py already provides a provider-agnostic client with stub fallback; this aligns with the Planner port.
 - Memory: existing short/long memory modules will be wrapped via ToolPort for agent tool calls.

--- a/docs/rag.md
+++ b/docs/rag.md
@@ -1,37 +1,48 @@
-# Retrieval and RAG Configuration
+# Retrieval Configuration
 
-Overview
-- The project supports two retrieval paths:
-  1) Deterministic retriever (default in tests/CI): scans DOCS_PATH files and merges snippets for reproducible citations with no network calls.
-  2) LangChain retriever (opt-in for local/prod): persistent vector store with embeddings (Chroma by default), powered by scripts/ingest_docs.py.
-- Tests are written to be deterministic by default; production setups may enable LangChain.
+## What exists today
 
-Key environment flags
-- LC_RAG_BACKEND=deterministic|langchain (default: deterministic for CI stability)
-- DOCS_PATH=./docs (or another folder with .md/.txt/.pdf)
-- VECTORSTORE_PATH=./.local/vectorstore (Chroma persistence when using LangChain)
-- EMBEDDINGS_PROVIDER=stub|local|openai (stub/local recommended for determinism)
-- RAG_MULTI_QUERY_ENABLED=false (experimental; defaults shown)
-- RAG_MULTI_QUERY_COUNT=3
-- RAG_HYDE_ENABLED=false
+There is one retrieval path: a deterministic keyword scan implemented in
+`app/services/doc_retriever.py` (renamed from `langchain_rag.py`, which never
+used LangChain).
 
-Today’s defaults
-- Deterministic retriever is the default to keep tests and local dev reproducible.
-- If you explicitly set LC_RAG_BACKEND=langchain, Chroma is used by default for persistence.
+How it works:
 
-Ingestion workflow (LangChain mode)
-1) Place .md/.txt/.pdf files under DOCS_PATH
-2) Run: `python scripts/ingest_docs.py`
-3) Start the API: `uvicorn app.main:app --reload`
-4) Query with grounding and expect citations when relevant: see docs/api.md or README for curl examples.
+1. The question is normalized into keyword terms (stopwords removed,
+   domain terms like `gdpr`/`pii` preserved).
+2. Every `.md`/`.txt` file under `DOCS_PATH` is scanned and scored by term
+   overlap.
+3. Top-scoring files are returned as citations with a 200-character snippet.
+4. The answer is extractive, composed from the returned snippets. When
+   nothing matches, citations are empty and the answer says so; no
+   placeholder content is fabricated.
 
-Determinism notes
-- CI and unit tests assume deterministic retrieval; avoid changing defaults that would fetch embeddings over the network.
-- If credentials or vector stores are missing in LangChain mode, the system should gracefully fall back to deterministic retrieval.
+There are no embeddings, no vector store, and no LLM calls in this path.
+That is deliberate for now: results are fully deterministic, which keeps
+tests and CI reproducible and offline.
 
-Roadmap and backends
-- For Pinecone and other managed vector DBs, see rag_vector_backends.md for the plan and additional env flags (LC_VECTOR_BACKEND=pinecone, etc.).
+## Environment flags
 
-See also
-- ports_and_adapters.md: RAGPort design, backends, capabilities, and fallbacks
-- related_projects.md: ecosystem projects (LangChain, LlamaIndex, Haystack, SK) and how we integrate
+- `DOCS_PATH=./docs` — corpus root (`.md`/`.txt`; `scripts/ingest_docs.py`
+  can extract text from PDFs)
+- `RAG_MULTI_QUERY_ENABLED=false` — expand the question into deterministic
+  variants before scanning
+- `RAG_MULTI_QUERY_COUNT=3` — number of variants when enabled
+- `RAG_HYDE_ENABLED=false` — add a deterministic hypothetical-snippet variant
+
+These flags are propagated into the audit record (`rag_multi_query`,
+`rag_multi_count`, `rag_hyde`), and the audit reports
+`rag_backend=keyword_scan`.
+
+## What is planned
+
+Real vector retrieval (sentence-transformers embeddings + Chroma behind a
+`RAG_BACKEND` flag, with the keyword scan kept as the deterministic
+fallback) is row C of [MODERNIZATION_PLAN.md](MODERNIZATION_PLAN.md). Until
+that lands, this repo does not do semantic retrieval, and docs should not
+claim it does. See `rag_vector_backends.md` for the backend plan.
+
+## See also
+
+- `ports_and_adapters.md`: RAGPort design and how backends will plug in
+- `docs/adr/0005-doc-retriever-naming.md`: why the module was renamed

--- a/docs/rag_vector_backends.md
+++ b/docs/rag_vector_backends.md
@@ -38,7 +38,7 @@ Operational notes
 
 Migration plan (later)
 1) Introduce LC_VECTOR_BACKEND with default chroma and optional pinecone.
-2) Add Pinecone wiring in app/services/langchain_rag.py behind env flags.
+2) Add Pinecone wiring in app/services/doc_retriever.py behind env flags.
 3) Extend scripts/ingest_docs.py to support Pinecone.
 4) Provide a diagnostic route or script to list collection/index counts across backends.
 

--- a/tests/test_query_langchain.py
+++ b/tests/test_query_langchain.py
@@ -4,7 +4,7 @@ from app.main import app
 
 
 def test_query_langchain_backend_with_flag(monkeypatch, tmp_path):
-    # LC is default now; ensure clean paths
+    # keyword-scan retriever is the default; ensure clean paths
     # Point to a temp docs dir
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
@@ -22,5 +22,5 @@ def test_query_langchain_backend_with_flag(monkeypatch, tmp_path):
     data = resp.json()
     assert "answer" in data
     assert isinstance(data["citations"], list)
-    # With LC wrapper scanning DOCS_PATH, we should get at least one citation
+    # With the retriever scanning DOCS_PATH, we should get at least one citation
     assert len(data["citations"]) >= 1

--- a/tests/test_rag_idempotent.py
+++ b/tests/test_rag_idempotent.py
@@ -1,13 +1,13 @@
 def test_rag_ingest_idempotent(tmp_path, monkeypatch):
-    # With LC-only path, ensure idempotent doc scan doesn't error and yields stable citations
+    # Ensure idempotent doc scan doesn't error and yields stable citations
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
     f = docs_dir / "a.txt"
     f.write_text("hello world")
 
-    # Point DOCS_PATH and query via LC backend to ensure stable behavior
+    # Point DOCS_PATH at temp docs to ensure stable behavior
     monkeypatch.setenv("DOCS_PATH", str(docs_dir))
-    from app.services.langchain_rag import answer_with_citations
+    from app.services.doc_retriever import answer_with_citations
 
     resp1 = answer_with_citations("hello", k=3)
     resp2 = answer_with_citations("hello", k=3)

--- a/tests/test_rag_multi_query.py
+++ b/tests/test_rag_multi_query.py
@@ -12,7 +12,7 @@ def test_rag_multi_query_and_hyde_flags(tmp_path):
     os.environ["RAG_MULTI_QUERY_ENABLED"] = "true"
     os.environ["RAG_MULTI_QUERY_COUNT"] = "3"
     os.environ["RAG_HYDE_ENABLED"] = "true"
-    # no embeddings provider needed for LC-only stub
+    # no embeddings provider needed for the keyword-scan retriever
     headers = {"X-User-Role": "analyst"}
     r = client.post(
         "/query",
@@ -26,8 +26,8 @@ def test_rag_multi_query_and_hyde_flags(tmp_path):
     body = r.json()
     assert "audit" in body
     audit = body["audit"]
-    # audit backend is langchain now
-    assert audit.get("rag_backend") == "langchain"
+    # audit backend reflects the actual retriever
+    assert audit.get("rag_backend") == "keyword_scan"
     assert audit.get("router_intent") in ("qa", None)
     # flags may not be present in response_audit depending on filtering; check nested audit_dict fallback
     # We at least ensure the call succeeded and returned citations list


### PR DESCRIPTION
## What

Row B of [docs/MODERNIZATION_PLAN.md](../blob/main/docs/MODERNIZATION_PLAN.md): rename `app/services/langchain_rag.py` → `app/services/doc_retriever.py` and retire the placeholder response paths.

## Why

The module never used LangChain. It is a deterministic keyword/file scan over `DOCS_PATH`. The old name, its docstrings, and `docs/rag.md` described a LangChain RetrievalQA / Chroma vector path that does not exist in the code (`LC_RAG_BACKEND` / `VECTORSTORE_PATH` were documented but read nowhere). Decision recorded in ADR 0005.

## Changes

- Rename module + update all 7 import sites and stale comments.
- Extractive answers built from matched snippets replace the hardcoded "This is a stubbed answer..." string.
- Remove the fabricated `source: synthetic` citation fallback in both the module and the duplicated `/query` safety-net block (~60 lines of dead duplication); real-file fallbacks remain.
- `audit.rag_backend` now reports `keyword_scan` instead of `langchain`.
- Rewrite `docs/rag.md` to describe only what exists; update module references across docs; add `docs/adr/0005-doc-retriever-naming.md`; CHANGELOG entry.

## API-visible changes

- Grounded `/query` answers contain extracted snippets instead of the stub sentence.
- `audit.rag_backend` value changes (`langchain` → `keyword_scan`).
- Empty/missing corpus now yields zero citations instead of a fabricated one.
- Callers consuming only `citations` (architect, PII remediation, policy navigator) are unaffected. OpenAPI schema: no drift.

## Verification

- Full suite: 108 passed locally (`MLFLOW_ALLOW_FILE_STORE=true pytest -q`).
- `ruff check .` clean; `scripts/export_openapi.py` produces no schema drift.

No vector RAG here; that is row C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)