### PR TITLE
feat: Chroma vector retrieval behind RAG_BACKEND (plan row C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+* Real vector retrieval behind `RAG_BACKEND=vector`: Chroma-backed `app/services/vector_retriever.py` with cosine ranking over chunked documents; `scripts/ingest_docs.py` now actually ingests (chunk + embed + upsert, idempotent ids); keyword scan remains the default and the fallback when the vectorstore is missing or empty; audit `rag_backend` reports the backend actually used.
+* Deterministic `hash` embeddings provider (hashed bag-of-words) for offline golden-query tests; `EMBEDDINGS_PROVIDER=local|hash|stub`.
+* `tests/test_vector_rag.py`: golden-query ranking, determinism, vector→keyword fallback, endpoint audit reporting, and empty-corpus (no fabricated citations) contracts.
+
 ### Changed
 
 * Rename `app/services/langchain_rag.py` → `app/services/doc_retriever.py`; the module is a deterministic keyword-scan retriever and never used LangChain (`docs/adr/0005-doc-retriever-naming.md`).

--- a/app/routers/query.py
+++ b/app/routers/query.py
@@ -138,6 +138,7 @@ def post_query(req: Request, payload: QueryRequest):
             result = answer_with_citations(payload.question, k=3)
             citations = [Citation(**c) for c in result.get("citations", [])]
             answer = result.get("answer") or ""
+            rag_backend = result.get("rag_backend") or rag_backend
             # stash result flags to propagate later (after audit_dict exists)
             rag_flags = {
                 k: result[k]

--- a/app/services/doc_retriever.py
+++ b/app/services/doc_retriever.py
@@ -1,10 +1,11 @@
-"""Deterministic keyword-scan document retriever.
+"""Document retrieval facade: keyword scan plus optional vector backend.
 
-Scans text files under DOCS_PATH, scores them by keyword overlap with the
-question, and returns snippet citations. There are no embeddings, no vector
-store, and no LLM calls; results are fully deterministic, which keeps tests
-and CI reproducible. A real vector-retrieval backend is planned separately
-(see docs/MODERNIZATION_PLAN.md, row C).
+The default path scans text files under DOCS_PATH, scores them by keyword
+overlap with the question, and returns snippet citations, with no
+embeddings and no LLM calls, so tests and CI stay deterministic. With
+RAG_BACKEND=vector, retrieval is delegated to the Chroma-backed
+vector_retriever (falling back to the keyword scan when the vectorstore
+is missing or empty).
 """
 
 import os
@@ -146,7 +147,13 @@ def _merge_citations(
 
 
 def answer_with_citations(question: str, k: int = 3) -> Dict[str, Any]:
-    """Return citations from a deterministic keyword scan of DOCS_PATH.
+    """Return citations from the configured retrieval backend.
+
+    RAG_BACKEND=vector uses Chroma vector retrieval (see vector_retriever);
+    anything else (default: keyword_scan) uses the deterministic keyword
+    scan of DOCS_PATH. The vector path falls back to the keyword scan when
+    the vectorstore is missing or empty, and the result reports the backend
+    actually used under the "rag_backend" key.
 
     The answer is extractive: it is composed from the top-ranked snippets.
     When nothing matches, citations are empty and the answer says so; no
@@ -154,8 +161,22 @@ def answer_with_citations(question: str, k: int = 3) -> Dict[str, Any]:
     """
     docs_path = os.getenv("DOCS_PATH", "./examples")
 
+    if os.getenv("RAG_BACKEND", "keyword_scan").lower() == "vector":
+        try:
+            from app.services import vector_retriever
+
+            if vector_retriever.is_ready():
+                citations = vector_retriever.query(question, k=k)
+                return {
+                    "answer": _extractive_answer(citations, k, docs_path),
+                    "citations": citations,
+                    "rag_backend": "vector",
+                }
+        except Exception:
+            pass  # fall back to the keyword scan below
+
     citations: List[Dict[str, Any]] = []
-    meta: Dict[str, Any] = {}
+    meta: Dict[str, Any] = {"rag_backend": "keyword_scan"}
     try:
         multi = os.getenv("RAG_MULTI_QUERY_ENABLED", "false").lower() in (
             "1",
@@ -233,18 +254,22 @@ def answer_with_citations(question: str, k: int = 3) -> Dict[str, Any]:
                     "snippet": snippet,
                 }
             ]
-    if citations:
-        parts = []
-        for c in citations[:k]:
-            src = c.get("source", "unknown")
-            snippet = (c.get("snippet") or "").strip()
-            if snippet:
-                parts.append(f"[{src}] {snippet}")
-        answer = (
-            "Extracted from matching documents:\n" + "\n".join(parts)
-            if parts
-            else "Matching documents found; see citations."
-        )
-    else:
-        answer = f"No documents under {docs_path} matched the question."
-    return {"answer": answer, "citations": citations, **meta}
+    return {
+        "answer": _extractive_answer(citations, k, docs_path),
+        "citations": citations,
+        **meta,
+    }
+
+
+def _extractive_answer(citations: List[Dict[str, Any]], k: int, docs_path: str) -> str:
+    if not citations:
+        return f"No documents under {docs_path} matched the question."
+    parts = []
+    for c in citations[:k]:
+        src = c.get("source", "unknown")
+        snippet = (c.get("snippet") or "").strip()
+        if snippet:
+            parts.append(f"[{src}] {snippet}")
+    if not parts:
+        return "Matching documents found; see citations."
+    return "Extracted from matching documents:\n" + "\n".join(parts)

--- a/app/services/vector_retriever.py
+++ b/app/services/vector_retriever.py
@@ -1,0 +1,116 @@
+"""Chroma-backed vector retrieval over ingested document chunks.
+
+Enabled with RAG_BACKEND=vector. Chunks are ingested into a persistent
+Chroma collection by scripts/ingest_docs.py; queries embed the question
+with the configured provider and return the top-k chunks as citations.
+
+Embedding providers (EMBEDDINGS_PROVIDER):
+- local: sentence-transformers (real semantic retrieval; downloads a model)
+- hash:  deterministic hashed bag-of-words (offline; used in tests/CI)
+- stub:  length-based vectors from rag_retriever (degenerate for ranking;
+         kept only for compatibility)
+
+The caller (doc_retriever.answer_with_citations) falls back to the
+deterministic keyword scan when this backend is unavailable or empty.
+"""
+
+import hashlib
+import os
+import re
+from typing import Any, Dict, List
+
+DEFAULT_COLLECTION = "docs"
+HASH_DIM = 384
+
+
+def vectorstore_path() -> str:
+    return os.getenv("VECTORSTORE_PATH", "./.local/vectorstore")
+
+
+def collection_name() -> str:
+    return os.getenv("RAG_COLLECTION", DEFAULT_COLLECTION)
+
+
+class HashEmbeddings:
+    """Deterministic hashed bag-of-words embeddings.
+
+    Tokens are hashed into a fixed number of buckets and counted, so texts
+    sharing vocabulary land close under cosine distance. No network, no
+    model download; suitable for CI golden-query tests.
+    """
+
+    def embed(self, texts: List[str]) -> List[List[float]]:
+        out: List[List[float]] = []
+        for text in texts:
+            vec = [0.0] * HASH_DIM
+            for tok in re.findall(r"[a-z0-9]+", text.lower()):
+                bucket = int(hashlib.md5(tok.encode()).hexdigest(), 16) % HASH_DIM
+                vec[bucket] += 1.0
+            norm = sum(v * v for v in vec) ** 0.5
+            if norm > 0:
+                vec = [v / norm for v in vec]
+            out.append(vec)
+        return out
+
+
+def get_embedder():
+    provider = os.getenv("EMBEDDINGS_PROVIDER", "local").lower()
+    if provider == "hash":
+        return HashEmbeddings()
+    if provider == "stub":
+        from app.services.rag_retriever import StubEmbeddings
+
+        return StubEmbeddings()
+    from app.services.rag_retriever import LocalEmbeddings
+
+    return LocalEmbeddings()
+
+
+def get_collection(create: bool = False):
+    import chromadb
+
+    client = chromadb.PersistentClient(path=vectorstore_path())
+    if create:
+        return client.get_or_create_collection(
+            collection_name(), metadata={"hnsw:space": "cosine"}
+        )
+    return client.get_collection(collection_name())
+
+
+def is_ready() -> bool:
+    """True when a non-empty collection exists at VECTORSTORE_PATH."""
+    try:
+        return get_collection().count() > 0
+    except Exception:
+        return False
+
+
+def query(question: str, k: int = 3) -> List[Dict[str, Any]]:
+    """Return top-k chunk citations for the question.
+
+    Raises on any backend failure; the caller decides whether to fall back.
+    """
+    col = get_collection()
+    emb = get_embedder().embed([question])[0]
+    res = col.query(
+        query_embeddings=[emb],
+        n_results=max(1, k),
+        include=["documents", "metadatas", "distances"],
+    )
+    citations: List[Dict[str, Any]] = []
+    ids = res.get("ids") or [[]]
+    docs = (res.get("documents") or [[]])[0]
+    metas = (res.get("metadatas") or [[]])[0]
+    dists = (res.get("distances") or [[]])[0]
+    for i in range(len(ids[0])):
+        meta = metas[i] if i < len(metas) else {}
+        snippet = (docs[i] if i < len(docs) else "")[:200].replace("\n", " ")
+        citations.append(
+            {
+                "source": (meta or {}).get("source", ids[0][i]),
+                "page": (meta or {}).get("page"),
+                "snippet": snippet,
+                "distance": round(dists[i], 4) if i < len(dists) else None,
+            }
+        )
+    return citations

--- a/docs/rag.md
+++ b/docs/rag.md
@@ -1,48 +1,61 @@
 # Retrieval Configuration
 
-## What exists today
+## Two retrieval backends
 
-There is one retrieval path: a deterministic keyword scan implemented in
-`app/services/doc_retriever.py` (renamed from `langchain_rag.py`, which never
-used LangChain).
+`app/services/doc_retriever.py` is the retrieval facade. `RAG_BACKEND`
+selects the backend:
 
-How it works:
+1. **`keyword_scan` (default).** Deterministic keyword scan: the question is
+   normalized into terms (stopwords removed, domain terms like `gdpr`/`pii`
+   preserved), every `.md`/`.txt` file under `DOCS_PATH` is scored by term
+   overlap, and top files come back as citations with 200-character
+   snippets. No embeddings, no vector store, no LLM calls, so tests and CI
+   stay reproducible and offline.
+2. **`vector`.** Chroma-backed semantic retrieval
+   (`app/services/vector_retriever.py`): document chunks are ingested into
+   a persistent Chroma collection by `scripts/ingest_docs.py` and queried
+   by cosine similarity over the configured embeddings. If the vectorstore
+   is missing or empty, retrieval falls back to the keyword scan, and the
+   result reports the backend actually used.
 
-1. The question is normalized into keyword terms (stopwords removed,
-   domain terms like `gdpr`/`pii` preserved).
-2. Every `.md`/`.txt` file under `DOCS_PATH` is scanned and scored by term
-   overlap.
-3. Top-scoring files are returned as citations with a 200-character snippet.
-4. The answer is extractive, composed from the returned snippets. When
-   nothing matches, citations are empty and the answer says so; no
-   placeholder content is fabricated.
+In both cases the answer is extractive, composed from the returned
+snippets. When nothing matches, citations are empty and the answer says so;
+no placeholder content is fabricated.
 
-There are no embeddings, no vector store, and no LLM calls in this path.
-That is deliberate for now: results are fully deterministic, which keeps
-tests and CI reproducible and offline.
+## Ingestion (vector backend)
+
+1. Place `.md`/`.txt`/`.pdf` files under `DOCS_PATH`
+2. Run `python scripts/ingest_docs.py` (chunks of 1000 chars with 200
+   overlap; idempotent, ids derive from path + offset)
+3. Set `RAG_BACKEND=vector` and query with `grounded=true`
 
 ## Environment flags
 
-- `DOCS_PATH=./docs` — corpus root (`.md`/`.txt`; `scripts/ingest_docs.py`
-  can extract text from PDFs)
-- `RAG_MULTI_QUERY_ENABLED=false` — expand the question into deterministic
-  variants before scanning
-- `RAG_MULTI_QUERY_COUNT=3` — number of variants when enabled
-- `RAG_HYDE_ENABLED=false` — add a deterministic hypothetical-snippet variant
+- `RAG_BACKEND=keyword_scan|vector` (default: `keyword_scan`)
+- `DOCS_PATH=./docs` — corpus root
+- `VECTORSTORE_PATH=./.local/vectorstore` — Chroma persistence dir
+- `RAG_COLLECTION=docs` — Chroma collection name
+- `EMBEDDINGS_PROVIDER=local|hash|stub` — `local` uses
+  sentence-transformers (`LOCAL_EMBEDDING_MODEL`, default all-MiniLM-L6-v2);
+  `hash` is a deterministic hashed bag-of-words used by CI golden-query
+  tests (offline, no model download); `stub` is the legacy length-based
+  stub (degenerate for ranking, kept for compatibility)
+- `RAG_MULTI_QUERY_ENABLED=false`, `RAG_MULTI_QUERY_COUNT=3`,
+  `RAG_HYDE_ENABLED=false` — deterministic query-expansion flags
+  (keyword-scan path)
 
-These flags are propagated into the audit record (`rag_multi_query`,
-`rag_multi_count`, `rag_hyde`), and the audit reports
-`rag_backend=keyword_scan`.
+The audit record reports `rag_backend` as the backend actually used
+(`keyword_scan` or `vector`), plus the query-expansion flags.
 
-## What is planned
+## Testing
 
-Real vector retrieval (sentence-transformers embeddings + Chroma behind a
-`RAG_BACKEND` flag, with the keyword scan kept as the deterministic
-fallback) is row C of [MODERNIZATION_PLAN.md](MODERNIZATION_PLAN.md). Until
-that lands, this repo does not do semantic retrieval, and docs should not
-claim it does. See `rag_vector_backends.md` for the backend plan.
+`tests/test_vector_rag.py` holds golden-query tests: a small corpus is
+ingested with `EMBEDDINGS_PROVIDER=hash` and each query must rank its
+expected source first, plus determinism, fallback, and empty-corpus
+contracts. Keep new tests offline; never depend on a model download.
 
 ## See also
 
-- `ports_and_adapters.md`: RAGPort design and how backends will plug in
+- `rag_vector_backends.md`: backend matrix and planned managed backends
+- `ports_and_adapters.md`: RAGPort design and how backends plug in
 - `docs/adr/0005-doc-retriever-naming.md`: why the module was renamed

--- a/docs/rag_vector_backends.md
+++ b/docs/rag_vector_backends.md
@@ -1,47 +1,47 @@
-# RAG Vector Backends (Roadmap + How To)
+# RAG Vector Backends
 
-Today
-- Default: Deterministic retriever for CI/local reproducibility.
-- Optional: LangChain + Chroma (embedded, persistent).
-- Switch using env: `LC_RAG_BACKEND=deterministic|langchain` (default: deterministic).
-- Vector store flags (LangChain mode):
-  - LC_VECTOR_BACKEND=chroma (default)
-  - VECTORSTORE_PATH=./.local/vectorstore
-  - DOCS_PATH=./docs
+## Today
 
-How to use LangChain + Chroma now
-1) Set LC_RAG_BACKEND=langchain
-2) Optionally set EMBEDDINGS_PROVIDER=local or openai (stub/local recommended for tests)
-3) Run `python scripts/ingest_docs.py`
-4) Start API and query with grounded=true
+- Default: deterministic keyword scan (`RAG_BACKEND=keyword_scan`) for
+  CI/local reproducibility.
+- Real vector retrieval: Chroma (embedded, persistent) via
+  `RAG_BACKEND=vector`, implemented in `app/services/vector_retriever.py`.
+  See `rag.md` for flags, ingestion, and fallback behavior.
+- Embeddings: `EMBEDDINGS_PROVIDER=local|hash|stub`. `local` uses
+  sentence-transformers; `hash` is the deterministic offline provider used
+  by golden-query tests.
 
-Pinecone (planned)
-- Goal: drop‑in alternative to Chroma when LC_RAG_BACKEND=langchain for managed scale and HA.
+There is no LangChain in the retrieval path; the old
+`LC_RAG_BACKEND`/`LC_VECTOR_BACKEND` flags never existed in code and are
+gone from the docs.
+
+## Pinecone (planned)
+
+Goal: drop-in managed alternative to Chroma for scale/HA.
+
 - Proposed env flags:
-  - LC_VECTOR_BACKEND=pinecone
-  - PINECONE_API_KEY=...
-  - PINECONE_ENVIRONMENT=...   # e.g., gcp-starter
-  - PINECONE_INDEX_NAME=ai-architect
-  - (Optional) PINECONE_NAMESPACE=default
-- Behavior:
-  - If LC_RAG_BACKEND=langchain and LC_VECTOR_BACKEND=pinecone, initialize Pinecone via LangChain using the configured embedding model.
-  - If credentials are missing or init fails, fall back to Chroma; if Chroma is unavailable, fall back to deterministic retriever.
+  - `VECTOR_BACKEND=pinecone` (default `chroma`)
+  - `PINECONE_API_KEY=...`
+  - `PINECONE_INDEX_NAME=ai-architect`
+  - optional `PINECONE_NAMESPACE=default`
+- Behavior: with `RAG_BACKEND=vector` and `VECTOR_BACKEND=pinecone`,
+  initialize Pinecone with the configured embedder. If credentials are
+  missing or init fails, fall back to Chroma; if Chroma is unavailable,
+  fall back to the keyword scan.
+- Migration steps: introduce `VECTOR_BACKEND` in `vector_retriever.py`,
+  extend `scripts/ingest_docs.py`, add a diagnostic to report
+  collection/index counts per backend.
 
-Embeddings
-- EMBEDDINGS_PROVIDER=openai|local|stub (default: stub/local for deterministic tests)
-- OPENAI_API_KEY=... (required for OpenAI embeddings)
-- EMBEDDING_MODEL or LLM_MODEL can be used to select specific models depending on provider.
+## Operational notes
 
-Operational notes
-- Local/dev/test: stay with deterministic or langchain+chroma for zero‑ops.
-- Production: consider langchain+pinecone; monitor costs and index sizes; use namespaces for multi‑tenant.
+- Local/dev/test: keyword scan or Chroma; zero ops, fully offline with
+  `EMBEDDINGS_PROVIDER=hash`.
+- Production: consider Pinecone once wired; watch index size and cost; use
+  namespaces for multi-tenant.
 
-Migration plan (later)
-1) Introduce LC_VECTOR_BACKEND with default chroma and optional pinecone.
-2) Add Pinecone wiring in app/services/doc_retriever.py behind env flags.
-3) Extend scripts/ingest_docs.py to support Pinecone.
-4) Provide a diagnostic route or script to list collection/index counts across backends.
+## Safety and fallbacks
 
-Safety and fallbacks
-- All backends are optional; the app must continue to operate with deterministic retrieval when flags or credentials are missing.
-- Tests remain deterministic by default (no network).
+- All vector backends are optional; the app must keep operating on the
+  keyword scan when flags, stores, or credentials are missing.
+- Tests stay deterministic and offline by default (no model downloads, no
+  network).

--- a/scripts/ingest_docs.py
+++ b/scripts/ingest_docs.py
@@ -1,8 +1,14 @@
+"""Ingest DOCS_PATH into the Chroma vectorstore used by RAG_BACKEND=vector.
+
+Chunks .md/.txt (and .pdf via PyMuPDF) files under DOCS_PATH, embeds each
+chunk with the configured EMBEDDINGS_PROVIDER (local | hash | stub), and
+upserts them into a persistent Chroma collection at VECTORSTORE_PATH.
+Re-running is idempotent: chunk ids are derived from file path + offset.
+"""
+
 import os
 
 from dotenv import load_dotenv
-
-# Legacy retriever removed; script now validates docs exist and exits.
 
 load_dotenv()
 
@@ -38,12 +44,59 @@ def chunk_text(text: str, size: int = 1000, overlap: int = 200):
         start = max(0, end - overlap)
 
 
-def main():
-    # No vectorstore anymore; treat as validation/no-op.
-    if not os.path.isdir(DOCS_PATH):
-        raise SystemExit(f"Docs path not found: {DOCS_PATH}")
-    # Optionally, touch a marker file to indicate readiness
-    print(f"Docs path ready: {DOCS_PATH}")
+def iter_documents(docs_path: str):
+    for root, _, files in os.walk(docs_path):
+        for fn in sorted(files):
+            path = os.path.join(root, fn)
+            low = fn.lower()
+            try:
+                if low.endswith((".md", ".txt")):
+                    with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                        yield path, f.read()
+                elif low.endswith(".pdf"):
+                    yield path, extract_pdf_text(path)
+            except Exception as e:
+                print(f"skip {path}: {e}")
+
+
+def main() -> int:
+    from app.services.vector_retriever import get_collection, get_embedder
+
+    docs_path = os.getenv("DOCS_PATH", DOCS_PATH)
+    if not os.path.isdir(docs_path):
+        raise SystemExit(f"Docs path not found: {docs_path}")
+
+    embedder = get_embedder()
+    collection = get_collection(create=True)
+
+    ids, docs, metas = [], [], []
+    for path, text in iter_documents(docs_path):
+        rel = os.path.relpath(path, docs_path)
+        for offset, chunk in chunk_text(text):
+            if not chunk.strip():
+                continue
+            ids.append(f"{rel}:{offset}")
+            docs.append(chunk)
+            metas.append({"source": rel, "offset": offset})
+
+    if not ids:
+        print(f"No ingestible documents under {docs_path}")
+        return 0
+
+    batch = 64
+    for i in range(0, len(ids), batch):
+        j = i + batch
+        collection.upsert(
+            ids=ids[i:j],
+            documents=docs[i:j],
+            metadatas=metas[i:j],
+            embeddings=embedder.embed(docs[i:j]),
+        )
+    print(
+        f"Ingested {len(ids)} chunks from {docs_path} "
+        f"into collection '{collection.name}' (count={collection.count()})"
+    )
+    return len(ids)
 
 
 if __name__ == "__main__":

--- a/tests/test_vector_rag.py
+++ b/tests/test_vector_rag.py
@@ -1,0 +1,107 @@
+import importlib
+import os
+
+from fastapi.testclient import TestClient
+
+
+def _write_corpus(docs_dir):
+    docs_dir.mkdir()
+    (docs_dir / "gdpr.txt").write_text(
+        "GDPR is the European Union regulation on data protection and privacy. "
+        "It governs consent, data subject rights, and retention of personal data."
+    )
+    (docs_dir / "kubernetes.txt").write_text(
+        "Kubernetes orchestrates containers across a cluster. Pods, deployments, "
+        "and services are the core primitives for scheduling workloads."
+    )
+    (docs_dir / "mlflow.txt").write_text(
+        "MLflow tracks machine learning experiments, logging metrics, parameters, "
+        "and artifacts for model training runs."
+    )
+
+
+def _ingest(monkeypatch, tmp_path):
+    docs_dir = tmp_path / "docs"
+    _write_corpus(docs_dir)
+    monkeypatch.setenv("DOCS_PATH", str(docs_dir))
+    monkeypatch.setenv("VECTORSTORE_PATH", str(tmp_path / "vec"))
+    monkeypatch.setenv("EMBEDDINGS_PROVIDER", "hash")  # deterministic, offline
+    import scripts.ingest_docs as ingest_docs
+
+    importlib.reload(ingest_docs)
+    assert ingest_docs.main() > 0
+    return docs_dir
+
+
+def test_vector_golden_queries(monkeypatch, tmp_path):
+    _ingest(monkeypatch, tmp_path)
+    monkeypatch.setenv("RAG_BACKEND", "vector")
+    from app.services.doc_retriever import answer_with_citations
+
+    golden = {
+        "What does GDPR say about data retention?": "gdpr.txt",
+        "How does Kubernetes schedule pods in a cluster?": "kubernetes.txt",
+        "Where are experiment metrics and artifacts logged?": "mlflow.txt",
+    }
+    for question, expected_source in golden.items():
+        result = answer_with_citations(question, k=2)
+        assert result["rag_backend"] == "vector"
+        assert result["citations"], question
+        assert result["citations"][0]["source"] == expected_source, question
+        assert result["answer"].startswith("Extracted from matching documents:")
+
+
+def test_vector_retrieval_is_deterministic(monkeypatch, tmp_path):
+    _ingest(monkeypatch, tmp_path)
+    monkeypatch.setenv("RAG_BACKEND", "vector")
+    from app.services.doc_retriever import answer_with_citations
+
+    r1 = answer_with_citations("GDPR consent rules", k=3)
+    r2 = answer_with_citations("GDPR consent rules", k=3)
+    assert r1["citations"] == r2["citations"]
+
+
+def test_vector_falls_back_to_keyword_scan_when_empty(monkeypatch, tmp_path):
+    docs_dir = tmp_path / "docs"
+    _write_corpus(docs_dir)
+    monkeypatch.setenv("DOCS_PATH", str(docs_dir))
+    # point at a vectorstore that was never ingested
+    monkeypatch.setenv("VECTORSTORE_PATH", str(tmp_path / "empty-vec"))
+    monkeypatch.setenv("RAG_BACKEND", "vector")
+    from app.services.doc_retriever import answer_with_citations
+
+    result = answer_with_citations("GDPR data protection", k=3)
+    assert result["rag_backend"] == "keyword_scan"
+    assert result["citations"]
+    assert any("gdpr" in (c["source"] or "").lower() for c in result["citations"])
+
+
+def test_query_endpoint_reports_vector_backend(monkeypatch, tmp_path):
+    _ingest(monkeypatch, tmp_path)
+    monkeypatch.setenv("RAG_BACKEND", "vector")
+    from app.main import app
+
+    client = TestClient(app)
+    r = client.post(
+        "/query",
+        json={"question": "What does GDPR regulate?", "grounded": True},
+        headers={"X-User-Role": "analyst"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["audit"].get("rag_backend") == "vector"
+    assert len(data.get("citations", [])) >= 1
+    assert data["citations"][0]["source"] == "gdpr.txt"
+
+
+def test_empty_corpus_returns_no_citations(monkeypatch, tmp_path):
+    # keyword scan on an empty directory: honest empty result, nothing fabricated
+    empty = tmp_path / "empty-docs"
+    empty.mkdir()
+    monkeypatch.setenv("DOCS_PATH", str(empty))
+    monkeypatch.delenv("RAG_BACKEND", raising=False)
+    from app.services.doc_retriever import answer_with_citations
+
+    result = answer_with_citations("anything at all", k=3)
+    assert result["citations"] == []
+    assert result["answer"].startswith("No documents under")


### PR DESCRIPTION
## What

Row C of [docs/MODERNIZATION_PLAN.md](../blob/main/docs/MODERNIZATION_PLAN.md), the flagship: real vector retrieval behind a `RAG_BACKEND` flag, keyword scan kept as the deterministic default and fallback.

## Changes

- **`app/services/vector_retriever.py` (new):** persistent Chroma collection (`VECTORSTORE_PATH`, `RAG_COLLECTION`), cosine ranking over chunked documents, top-k chunks returned as citations with source/snippet/distance.
- **Embeddings:** `EMBEDDINGS_PROVIDER=local|hash|stub` — `local` = sentence-transformers (already a dependency), `hash` = new deterministic hashed bag-of-words provider so golden-query tests run offline with no model download, `stub` = legacy length-based vectors (kept for compatibility).
- **`scripts/ingest_docs.py`:** was a no-op validator; now chunks (1000/200 overlap), embeds, and idempotently upserts (ids = path:offset).
- **`doc_retriever` facade:** `RAG_BACKEND=vector` delegates to Chroma; missing/empty vectorstore falls back to the keyword scan; result carries `rag_backend` = backend actually used, surfaced in the `/query` audit.
- **Docs:** `rag.md` and `rag_vector_backends.md` updated to match; retired the fictional `LC_RAG_BACKEND`/`LC_VECTOR_BACKEND` flags from docs.

## Tests (5 new, tests/test_vector_rag.py)

Golden-query ranking (3 queries must rank their expected source first), determinism, vector→keyword fallback, endpoint audit reports `vector`, and empty-corpus honesty (zero citations, no fabrication).

## Verification

- Full suite 113 passed locally (`MLFLOW_ALLOW_FILE_STORE=true pytest -q`), `ruff check` clean, no OpenAPI drift.
- Chroma 1.5.9 PersistentClient API verified directly before wiring.

Defaults unchanged: without `RAG_BACKEND=vector` nothing differs. Pinecone remains planned (docs only). Row F (LangGraph agent) can now consume this per its dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)