### PR TITLE
feat: LiteLLM client with real per-model cost tracking (plan row E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* LiteLLM-backed `LLMClient`: all real providers route through `litellm.completion` (the hand-rolled openai/openrouter/azure branches are gone); the deterministic offline `stub` provider stays the default and the fallback on any provider error. `cost_usd` is now real, from LiteLLM's per-model pricing map, and `app/utils/cost.py` prices its estimates from the same map (static table only as fallback). Tests: `tests/test_llm_cost.py`.
+
 * Real vector retrieval behind `RAG_BACKEND=vector`: Chroma-backed `app/services/vector_retriever.py` with cosine ranking over chunked documents; `scripts/ingest_docs.py` now actually ingests (chunk + embed + upsert, idempotent ids); keyword scan remains the default and the fallback when the vectorstore is missing or empty; audit `rag_backend` reports the backend actually used.
 * Deterministic `hash` embeddings provider (hashed bag-of-words) for offline golden-query tests; `EMBEDDINGS_PROVIDER=local|hash|stub`.
 * `tests/test_vector_rag.py`: golden-query ranking, determinism, vector→keyword fallback, endpoint audit reporting, and empty-corpus (no fabricated citations) contracts.

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -3,9 +3,11 @@ from typing import Any, Dict, List, Optional
 
 from app.utils.logger import get_logger
 
-# Provider-agnostic LLM client with safe offline stub by default.
-# Returns a structured dict with text and audit metadata. When providers fail
-# or are not configured, it falls back to a deterministic stub to keep tests stable.
+# LLM client backed by LiteLLM for all real providers, with a safe offline
+# stub by default. Returns a structured dict with text and audit metadata
+# (tokens + real per-model cost_usd from LiteLLM's pricing map). When a
+# provider fails or is not configured, it falls back to the deterministic
+# stub to keep tests stable.
 
 
 class LLMClient:
@@ -22,15 +24,25 @@ class LLMClient:
             self.max_tokens = 512
         self._logger = get_logger("llm")
 
-    def _stub_call(self, messages: List[Dict[str, str]], reason: Optional[str] = None) -> Dict[str, Any]:
+    def _stub_call(
+        self, messages: List[Dict[str, str]], reason: Optional[str] = None
+    ) -> Dict[str, Any]:
         if reason:
             self._logger.warning(
-                "LLM fallback to stub", extra={"extra": {"provider": self.provider, "model": self.model, "reason": reason}}
+                "LLM fallback to stub",
+                extra={
+                    "extra": {
+                        "provider": self.provider,
+                        "model": self.model,
+                        "reason": reason,
+                    }
+                },
             )
-        prompt = "\n".join(m.get("content", "") for m in messages if m.get("role") != "system")
-        text = (
-            "[stub] This is a deterministic offline response. "
-            + (prompt[:200] if isinstance(prompt, str) else "")
+        prompt = "\n".join(
+            m.get("content", "") for m in messages if m.get("role") != "system"
+        )
+        text = "[stub] This is a deterministic offline response. " + (
+            prompt[:200] if isinstance(prompt, str) else ""
         )
         # Deterministic token estimates
         tp = max(1, len(prompt.split()))
@@ -44,121 +56,67 @@ class LLMClient:
             "cost_usd": 0.0,
         }
 
-    def call(self, messages: List[Dict[str, str]], model: Optional[str] = None, **kwargs) -> Dict[str, Any]:
+    def _litellm_model(self, model: str) -> str:
+        """Map provider + model to a LiteLLM model string."""
+        if "/" in model:
+            return model
+        if self.provider == "azure":
+            deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT") or model
+            return f"azure/{deployment}"
+        if self.provider == "openai":
+            return model
+        return f"{self.provider}/{model}"
+
+    def call(
+        self, messages: List[Dict[str, str]], model: Optional[str] = None, **kwargs
+    ) -> Dict[str, Any]:
         provider = self.provider
         model_to_use = model or self.model
         if provider == "stub":
             return self._stub_call(messages, reason="provider=stub configured")
         try:
-            if provider == "openai":
-                from openai import OpenAI  # type: ignore
+            import litellm
 
-                api_key = os.getenv("OPENAI_API_KEY")
-                if not api_key:
-                    return self._stub_call(messages, reason="missing OPENAI_API_KEY")
-                client = OpenAI(api_key=api_key)
-                params: Dict[str, Any] = {
-                    "model": model_to_use,
-                    "messages": messages,
-                    "max_completion_tokens": self.max_tokens,
-                }
-                # Some newer models only allow default temperature; omit when 0.0/None
-                if self.temperature not in (None, 0.0):
-                    params["temperature"] = self.temperature
-                try:
-                    resp = client.chat.completions.create(**params)
-                except Exception as e:
-                    # If temperature caused a 400, retry once without it
-                    msg = str(e)
-                    if "temperature" in msg and "unsupported" in msg.lower() and "temperature" in params:
-                        params.pop("temperature", None)
-                        resp = client.chat.completions.create(**params)
-                    else:
-                        raise
-                choice = resp.choices[0]
-                text = getattr(choice.message, "content", "") or ""
-                tp = getattr(resp.usage, "prompt_tokens", None) or 0
-                tc = getattr(resp.usage, "completion_tokens", None) or 0
-                # Cost estimation is provider/model specific; best-effort zero unless configured elsewhere
-                return {
-                    "text": text,
-                    "provider": provider,
-                    "model": model_to_use,
-                    "tokens_prompt": tp,
-                    "tokens_completion": tc,
-                    "cost_usd": 0.0,
-                }
-            if provider == "openrouter":
-                import requests  # type: ignore
+            params: Dict[str, Any] = {
+                "model": self._litellm_model(model_to_use),
+                "messages": messages,
+                "max_tokens": self.max_tokens,
+                # LiteLLM silently drops params a given model doesn't support
+                # (e.g. temperature on reasoning models).
+                "drop_params": True,
+            }
+            if self.temperature not in (None, 0.0):
+                params["temperature"] = self.temperature
+            resp = litellm.completion(**params)
 
-                api_key = os.getenv("OPENROUTER_API_KEY")
-                if not api_key:
-                    return self._stub_call(messages, reason="missing OPENROUTER_API_KEY")
-                headers = {
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                }
-                payload = {
-                    "model": model_to_use,
-                    "messages": messages,
-                    "temperature": self.temperature,
-                    "max_tokens": self.max_tokens,
-                }
-                r = requests.post("https://openrouter.ai/api/v1/chat/completions", json=payload, headers=headers, timeout=30)
+            text = resp.choices[0].message.content or ""
+            usage = getattr(resp, "usage", None)
+            tp = getattr(usage, "prompt_tokens", 0) or 0
+            tc = getattr(usage, "completion_tokens", 0) or 0
+
+            # Real per-model cost from LiteLLM's bundled pricing map.
+            try:
+                cost = float(litellm.completion_cost(completion_response=resp))
+            except Exception:
                 try:
-                    data = r.json()
+                    pc, cc = litellm.cost_per_token(
+                        model=params["model"],
+                        prompt_tokens=tp,
+                        completion_tokens=tc,
+                    )
+                    cost = float(pc) + float(cc)
                 except Exception:
-                    return self._stub_call(messages, reason=f"openrouter HTTP {r.status_code}")
-                text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
-                usage = data.get("usage", {})
-                tp = usage.get("prompt_tokens", 0)
-                tc = usage.get("completion_tokens", 0)
-                return {
-                    "text": text,
-                    "provider": provider,
-                    "model": model_to_use,
-                    "tokens_prompt": tp,
-                    "tokens_completion": tc,
-                    "cost_usd": 0.0,
-                }
-            if provider == "azure":
-                # Azure OpenAI compatible API
-                import requests  # type: ignore
+                    cost = 0.0
 
-                api_key = os.getenv("AZURE_OPENAI_API_KEY")
-                endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
-                deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT") or model_to_use
-                if not api_key or not endpoint:
-                    return self._stub_call(messages, reason="missing AZURE_OPENAI_API_KEY or AZURE_OPENAI_ENDPOINT")
-                url = f"{endpoint}/openai/deployments/{deployment}/chat/completions?api-version=2024-02-15-preview"
-                headers = {
-                    "api-key": api_key,
-                    "Content-Type": "application/json",
-                }
-                payload = {
-                    "messages": messages,
-                    "temperature": self.temperature,
-                    "max_tokens": self.max_tokens,
-                }
-                r = requests.post(url, json=payload, headers=headers, timeout=30)
-                try:
-                    data = r.json()
-                except Exception:
-                    return self._stub_call(messages, reason=f"azure HTTP {r.status_code}")
-                text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
-                usage = data.get("usage", {})
-                tp = usage.get("prompt_tokens", 0)
-                tc = usage.get("completion_tokens", 0)
-                return {
-                    "text": text,
-                    "provider": provider,
-                    "model": deployment or model_to_use,
-                    "tokens_prompt": tp,
-                    "tokens_completion": tc,
-                    "cost_usd": 0.0,
-                }
+            return {
+                "text": text,
+                "provider": provider,
+                "model": getattr(resp, "model", None) or model_to_use,
+                "tokens_prompt": tp,
+                "tokens_completion": tc,
+                "cost_usd": cost,
+            }
         except Exception as e:
-            # Last resort: stub with diagnostics
+            # Missing keys, unknown providers, and provider errors all land
+            # here: fall back to the deterministic stub with diagnostics.
             return self._stub_call(messages, reason=f"{provider} error: {e}")
-        # Unknown provider -> stub
-        return self._stub_call(messages, reason="unknown provider")

--- a/app/utils/cost.py
+++ b/app/utils/cost.py
@@ -1,12 +1,31 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
-# Very rough token and cost estimate for Phase 0
-# Prices are illustrative only
-PRICES_PER_1K = {
+# Token counts remain a crude ~4-chars-per-token estimate (good enough for
+# request-level accounting of non-LLM endpoints). Prices come from LiteLLM's
+# bundled per-model pricing map, so cost_usd tracks real published rates;
+# the static table below is only the fallback for unknown models.
+FALLBACK_PRICES_PER_1K = {
     "gpt-4o-mini": (0.15, 0.60),  # (prompt, completion) USD per 1k tokens
     "gpt-4.1": (5.0, 15.0),
     "stub": (0.0, 0.0),
 }
+
+
+def cost_for_tokens(model: str, tokens_prompt: int, tokens_completion: int) -> Optional[float]:
+    """Real per-model cost from LiteLLM's pricing map; None if unknown."""
+    if model == "stub":
+        return 0.0
+    try:
+        import litellm
+
+        pc, cc = litellm.cost_per_token(
+            model=model,
+            prompt_tokens=tokens_prompt,
+            completion_tokens=tokens_completion,
+        )
+        return float(pc) + float(cc)
+    except Exception:
+        return None
 
 
 def estimate_tokens_and_cost(
@@ -14,6 +33,8 @@ def estimate_tokens_and_cost(
 ) -> Tuple[int, int, float]:
     tp = max(1, len(prompt) // 4)  # crude: ~4 chars per token
     tc = max(1, len(completion) // 4)
-    price = PRICES_PER_1K.get(model, PRICES_PER_1K.get("gpt-4o-mini"))
-    cost = (tp / 1000.0) * price[0] + (tc / 1000.0) * price[1]
+    cost = cost_for_tokens(model, tp, tc)
+    if cost is None:
+        price = FALLBACK_PRICES_PER_1K.get(model, FALLBACK_PRICES_PER_1K["gpt-4o-mini"])
+        cost = (tp / 1000.0) * price[0] + (tc / 1000.0) * price[1]
     return tp, tc, cost

--- a/docs/capabilities_current.md
+++ b/docs/capabilities_current.md
@@ -14,7 +14,7 @@ Endpoints and behaviors
   - Intents: auto|qa|pii_detect|risk_score (router optional; default falls back to qa)
   - grounded=true: RAG path with citations; records rag flags (multi_query, hyde)
   - ungrouded (or grounded with optional LLM): optional LLM synthesis when LLM_ENABLE_QUERY=true
-  - Audit: tokens/cost estimates, router_backend and router_intent, rag_backend ("langchain" today), PII extras when pii_detect intent
+  - Audit: tokens/cost estimates, router_backend and router_intent, rag_backend (keyword_scan or vector), PII extras when pii_detect intent
 - POST /architect (requires PROJECT_GUIDE_ENABLED=true)
   - Structured plan generation via Architect Agent when LLM_ENABLE_ARCHITECT=true
   - When grounded, uses same RAG path for citations

--- a/docs/observability_metrics.md
+++ b/docs/observability_metrics.md
@@ -23,7 +23,7 @@ Exported metrics
   - Counter of tokens accounted (prompt + completion) per endpoint.
   - Updated by /query router after responses.
 - app_cost_usd_total{endpoint}
-  - Counter of estimated USD cost per endpoint.
+  - Counter of USD cost per endpoint. LLM calls use real per-model prices from LiteLLM's pricing map; non-LLM endpoints use a crude token estimate priced by the same map (static fallback for unknown models).
   - Updated by /query router after responses.
 
 Where metrics are defined

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "sqlalchemy>=2.0.32",
   "sentence-transformers==3.0.1",
   "openai>=1.51.2",
+  "litellm>=1.90.0",
   "langchain-core>=0.1.27",
   "pymupdf>=1.24.9",
   "mlflow>=2.15.0",

--- a/tests/test_llm_cost.py
+++ b/tests/test_llm_cost.py
@@ -1,0 +1,61 @@
+"""FinOps cost wiring: real per-model cost_usd via LiteLLM's pricing map."""
+
+import litellm
+
+from app.services.llm_client import LLMClient
+from app.utils.cost import cost_for_tokens, estimate_tokens_and_cost
+
+
+def test_llm_call_reports_real_cost(monkeypatch):
+    # Route through LiteLLM with a mocked response (no network); cost must
+    # come from the pricing map, not a hardcoded zero.
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "gpt-4o-mini")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    real_completion = litellm.completion
+
+    def _mocked(**params):
+        return real_completion(
+            model=params["model"],
+            messages=params["messages"],
+            mock_response="Hello from mocked provider",
+        )
+
+    monkeypatch.setattr(litellm, "completion", _mocked)
+
+    out = LLMClient().call([{"role": "user", "content": "hello there"}])
+    assert out["provider"] == "openai"
+    assert out["tokens_prompt"] > 0
+    assert out["tokens_completion"] > 0
+    expected = cost_for_tokens(
+        "gpt-4o-mini", out["tokens_prompt"], out["tokens_completion"]
+    )
+    assert expected is not None and expected > 0
+    assert out["cost_usd"] > 0
+    assert abs(out["cost_usd"] - expected) < 1e-9
+
+
+def test_stub_cost_is_zero(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "stub")
+    out = LLMClient().call([{"role": "user", "content": "hello"}])
+    assert out["cost_usd"] == 0.0
+
+
+def test_estimator_uses_litellm_pricing():
+    tp, tc, cost = estimate_tokens_and_cost(
+        model="gpt-4o-mini", prompt="p" * 400, completion="c" * 400
+    )
+    pc, cc = litellm.cost_per_token(
+        model="gpt-4o-mini", prompt_tokens=tp, completion_tokens=tc
+    )
+    assert cost == float(pc) + float(cc)
+    assert cost > 0
+
+
+def test_estimator_unknown_model_uses_fallback_table():
+    tp, tc, cost = estimate_tokens_and_cost(
+        model="totally-unknown-model", prompt="p" * 400, completion="c" * 400
+    )
+    # falls back to the gpt-4o-mini illustrative row
+    assert cost == (tp / 1000.0) * 0.15 + (tc / 1000.0) * 0.60

--- a/tests/test_llm_fallback_logging.py
+++ b/tests/test_llm_fallback_logging.py
@@ -1,14 +1,11 @@
-import os
-import importlib
-
 from app.services.llm_client import LLMClient
 
 
-def test_openai_unsupported_model_falls_back_with_warning(monkeypatch, capsys):
-    # Ensure provider is openai but with an unsupported model name
+def test_missing_api_key_falls_back_to_stub(monkeypatch):
+    # Provider configured but no credentials: LiteLLM raises client-side
+    # (no network) and the client falls back to the deterministic stub.
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("LLM_MODEL", "gpt-4o-mini")
-    # Missing key should trigger clear reason
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     client = LLMClient()
@@ -16,58 +13,29 @@ def test_openai_unsupported_model_falls_back_with_warning(monkeypatch, capsys):
 
     assert out["provider"] == "stub"
     assert out["model"] == "gpt-4o-mini"
+    assert out["cost_usd"] == 0.0
 
 
-def test_openai_exception_falls_back_with_reason(monkeypatch):
-    # Simulate openai client import and call raising
+def test_provider_exception_falls_back_to_stub(monkeypatch):
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("LLM_MODEL", "gpt-4o-mini")
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
 
-    class DummyChoice:
-        def __init__(self):
-            class M:
-                pass
-            self.message = M()
-            self.message.content = "ok"
+    import litellm
 
-    class DummyResp:
-        def __init__(self):
-            self.choices = [DummyChoice()]
-            class U:
-                pass
-            self.usage = U()
-            self.usage.prompt_tokens = 1
-            self.usage.completion_tokens = 1
-
-    def raise_error(*args, **kwargs):
+    def _boom(**kwargs):
         raise RuntimeError("boom")
 
-    class DummyClient:
-        class chat:
-            class completions:
-                @staticmethod
-                def create(**kwargs):
-                    raise_error()
+    monkeypatch.setattr(litellm, "completion", _boom)
 
-    # Patch OpenAI class to our dummy
-    import builtins
-    import types
+    client = LLMClient()
+    out = client.call([{"role": "user", "content": "hello"}])
+    assert out["provider"] == "stub"
 
-    class OpenAI:  # type: ignore
-        def __init__(self, *a, **k):
-            pass
-        class chat:  # type: ignore
-            class completions:  # type: ignore
-                @staticmethod
-                def create(**kwargs):
-                    raise RuntimeError("boom")
 
-    import sys
-    module_name = "openai"
-    mod = types.ModuleType(module_name)
-    mod.OpenAI = OpenAI
-    sys.modules[module_name] = mod
+def test_unknown_provider_falls_back_to_stub(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "not-a-real-provider")
+    monkeypatch.setenv("LLM_MODEL", "whatever")
 
     client = LLMClient()
     out = client.call([{"role": "user", "content": "hello"}])


### PR DESCRIPTION
## What

Row E of [docs/MODERNIZATION_PLAN.md](../blob/main/docs/MODERNIZATION_PLAN.md): swap the hand-rolled multi-provider LLM client for LiteLLM, keep the stub provider, and wire real `cost_usd` into the FinOps metrics.

## Changes

- **`LLMClient`:** the openai / openrouter / azure request-building branches (~120 lines incl. the temperature-retry hack) are replaced by one `litellm.completion` call with `drop_params=True`. Provider→model mapping handles `azure/` deployments and `provider/model` prefixes. The `stub` provider is unchanged: still the default, still fully offline, still the fallback on any provider error, so all existing tests and CI behavior hold.
- **Real cost:** `cost_usd` comes from `litellm.completion_cost` (fallback `cost_per_token`), replacing hardcoded `0.0` — this was the gap gutting the FinOps claim.
- **`app/utils/cost.py`:** request-level estimates now price via LiteLLM's bundled pricing map (`cost_for_tokens`); the old illustrative table survives only as a fallback for unknown models. Flows into `app_cost_usd_total` and audit rows.
- **Dependency:** `litellm>=1.90.0` added (verified against 1.90.3).
- Stale empty `feat/litellm` placeholder branch deleted from origin.

## Tests

- New `tests/test_llm_cost.py`: LiteLLM-routed call reports pricing-map cost (mocked response, no network), stub stays $0, estimator matches `litellm.cost_per_token`, unknown model falls back to the static table.
- `tests/test_llm_fallback_logging.py` rewritten for the LiteLLM seam: missing key, provider exception, and unknown provider all fall back to stub client-side (no network).

## Verification

Full suite 118 passed locally, `ruff check` clean, no OpenAPI drift. All fallback paths verified offline.

Next up: row F (LangGraph agent) — now fully unblocked (C + D merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)