### PR TITLE
feat: LangGraph tool-loop architect behind AGENT_BACKEND (plan row F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* Real LangGraph tool-loop architect behind `AGENT_BACKEND=langgraph` (`app/services/langgraph_architect.py`): the LLM decides per turn between calling `retrieve_docs` (via `doc_retriever`, vector backend applies) and finalizing; capped at 3 tool calls; tokens/cost accumulate across turns; audit reports `agent_backend` and `agent_tool_calls`. The deterministic builtin planner stays the default and the fallback on any failure (`docs/adr/0007-langgraph-architect.md`).
+
 * LiteLLM-backed `LLMClient`: all real providers route through `litellm.completion` (the hand-rolled openai/openrouter/azure branches are gone); the deterministic offline `stub` provider stays the default and the fallback on any provider error. `cost_usd` is now real, from LiteLLM's per-model pricing map, and `app/utils/cost.py` prices its estimates from the same map (static table only as fallback). Tests: `tests/test_llm_cost.py`.
 
 * Real vector retrieval behind `RAG_BACKEND=vector`: Chroma-backed `app/services/vector_retriever.py` with cosine ranking over chunked documents; `scripts/ingest_docs.py` now actually ingests (chunk + embed + upsert, idempotent ids); keyword scan remains the default and the fallback when the vectorstore is missing or empty; audit `rag_backend` reports the backend actually used.

--- a/app/services/architect_agent.py
+++ b/app/services/architect_agent.py
@@ -44,6 +44,22 @@ def _build_messages(question: str, plan_parser: PydanticOutputParser, context_bl
 
 
 def run_architect_agent(question: str, session_id: str | None = None, user_id: str | None = None, llm_model: str | None = None) -> Tuple[ArchitectPlan, Dict[str, Any]]:
+    # Optional LangGraph tool-loop backend (AGENT_BACKEND=langgraph); the
+    # deterministic builtin planner below stays the default, and any failure
+    # in the LangGraph path falls back to it.
+    if os.getenv("AGENT_BACKEND", "builtin").lower() == "langgraph":
+        try:
+            from app.services.langgraph_architect import run_langgraph_architect
+
+            return run_langgraph_architect(
+                question, session_id=session_id, user_id=user_id, llm_model=llm_model
+            )
+        except Exception as e:
+            _arch_logger.warning(
+                "langgraph backend failed; using builtin",
+                extra={"extra": {"error": str(e)}},
+            )
+
     # Initialize memory flags and counters
     short_enabled = os.getenv("MEMORY_SHORT_ENABLED", "false").lower() in ("1", "true", "yes", "on")
     long_enabled = os.getenv("MEMORY_LONG_ENABLED", "false").lower() in ("1", "true", "yes", "on")
@@ -278,6 +294,7 @@ def run_architect_agent(question: str, session_id: str | None = None, user_id: s
 
     # 7) Build audit fields with memory counters
     audit: Dict[str, Any] = {
+        "agent_backend": "builtin",
         "llm_provider": result.get("provider"),
         "llm_model": result.get("model"),
         "llm_tokens_prompt": result.get("tokens_prompt"),

--- a/app/services/langgraph_architect.py
+++ b/app/services/langgraph_architect.py
@@ -1,0 +1,202 @@
+"""LangGraph tool-loop architect agent (AGENT_BACKEND=langgraph).
+
+A real agent loop, in contrast to the deterministic linear pipeline in
+architect_agent.py: the LLM decides on each turn whether to call a tool
+(document retrieval) or finalize the plan, and observations feed back into
+the next turn. The graph:
+
+    agent -> (retrieve_docs) -> tools -> agent -> ... -> END
+
+The builtin planner remains the default backend; this path is opt-in and
+run_architect_agent falls back to the builtin on any failure here.
+"""
+
+import json
+import os
+from typing import Any, Dict, List, Optional, Tuple, TypedDict
+
+from langgraph.graph import END, StateGraph
+
+from app.services.architect_schema import ArchitectPlan
+from app.services.llm_client import LLMClient
+from app.utils.logger import get_logger
+
+_logger = get_logger("langgraph_architect")
+
+MAX_TOOL_CALLS = 3
+
+_SYSTEM = (
+    "You are the solution architect agent for the AI-Architect project. "
+    "You work in a loop: on each turn respond ONLY with one JSON object, either\n"
+    '  {"action": "retrieve_docs", "query": "<search query>"}\n'
+    "to look up project documentation, or\n"
+    '  {"action": "final", "summary": "<string>", "suggested_steps": ["..."], '
+    '"suggested_env_flags": ["..."]}\n'
+    "to finish. Use retrieve_docs when grounding would improve the plan; "
+    "finalize once you have enough context. No text outside the JSON object."
+)
+
+
+class AgentState(TypedDict, total=False):
+    question: str
+    messages: List[Dict[str, str]]
+    plan: Dict[str, Any]
+    citations: List[Dict[str, Any]]
+    tool_calls: int
+    pending_query: Optional[str]
+    tokens_prompt: int
+    tokens_completion: int
+    cost_usd: float
+    llm_provider: Optional[str]
+    llm_model: Optional[str]
+
+
+def _parse_decision(text: str) -> Dict[str, Any]:
+    raw = (text or "").strip()
+    if raw.startswith("```"):
+        lines = raw.splitlines()[1:]
+        if lines and lines[-1].strip().startswith("```"):
+            lines = lines[:-1]
+        raw = "\n".join(lines).strip()
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict) and data.get("action"):
+            return data
+    except Exception:
+        pass
+    # Not a tool-protocol reply: treat the text as a final summary rather
+    # than failing the whole run.
+    return {"action": "final", "summary": raw[:400]}
+
+
+def _make_agent_node(llm: LLMClient, llm_model: Optional[str]):
+    def agent_node(state: AgentState) -> AgentState:
+        messages = [{"role": "system", "content": _SYSTEM}] + state["messages"]
+        kwargs: Dict[str, Any] = {}
+        if llm_model:
+            kwargs["model"] = llm_model
+        result = llm.call(messages, **kwargs)
+        decision = _parse_decision(result.get("text") or "")
+
+        update: AgentState = {
+            "tokens_prompt": state.get("tokens_prompt", 0)
+            + int(result.get("tokens_prompt") or 0),
+            "tokens_completion": state.get("tokens_completion", 0)
+            + int(result.get("tokens_completion") or 0),
+            "cost_usd": state.get("cost_usd", 0.0)
+            + float(result.get("cost_usd") or 0.0),
+            "llm_provider": result.get("provider"),
+            "llm_model": result.get("model"),
+            "messages": state["messages"]
+            + [{"role": "assistant", "content": result.get("text") or ""}],
+        }
+        if (
+            decision.get("action") == "retrieve_docs"
+            and state.get("tool_calls", 0) < MAX_TOOL_CALLS
+        ):
+            update["pending_query"] = str(
+                decision.get("query") or state["question"]
+            )
+        else:
+            update["pending_query"] = None
+            update["plan"] = {
+                "summary": str(decision.get("summary") or ""),
+                "suggested_steps": [
+                    str(s) for s in (decision.get("suggested_steps") or [])
+                ],
+                "suggested_env_flags": [
+                    str(f) for f in (decision.get("suggested_env_flags") or [])
+                ],
+            }
+        return update
+
+    return agent_node
+
+
+def _tools_node(state: AgentState) -> AgentState:
+    from app.services.doc_retriever import answer_with_citations
+
+    query = state.get("pending_query") or state["question"]
+    result = answer_with_citations(query, k=3)
+    citations = result.get("citations", [])
+    observation = result.get("answer") or "No matching documents."
+    return {
+        "tool_calls": state.get("tool_calls", 0) + 1,
+        "citations": state.get("citations", []) + citations,
+        "pending_query": None,
+        "messages": state["messages"]
+        + [
+            {
+                "role": "user",
+                "content": f"Tool result for retrieve_docs({query!r}):\n{observation}",
+            }
+        ],
+    }
+
+
+def _route(state: AgentState) -> str:
+    return "tools" if state.get("pending_query") else END
+
+
+def build_graph(llm: LLMClient, llm_model: Optional[str] = None):
+    graph = StateGraph(AgentState)
+    graph.add_node("agent", _make_agent_node(llm, llm_model))
+    graph.add_node("tools", _tools_node)
+    graph.set_entry_point("agent")
+    graph.add_conditional_edges("agent", _route, {"tools": "tools", END: END})
+    graph.add_edge("tools", "agent")
+    return graph.compile()
+
+
+def run_langgraph_architect(
+    question: str,
+    session_id: str | None = None,
+    user_id: str | None = None,
+    llm_model: str | None = None,
+) -> Tuple[ArchitectPlan, Dict[str, Any]]:
+    llm = LLMClient()
+    app = build_graph(llm, llm_model)
+    final: AgentState = app.invoke(
+        {
+            "question": question,
+            "messages": [{"role": "user", "content": question}],
+            "citations": [],
+            "tool_calls": 0,
+            "tokens_prompt": 0,
+            "tokens_completion": 0,
+            "cost_usd": 0.0,
+        }
+    )
+
+    plan_data = final.get("plan") or {}
+    try:
+        plan = ArchitectPlan(**plan_data)
+    except Exception:
+        plan = ArchitectPlan(summary=str(plan_data.get("summary", "")))
+    citations = final.get("citations", [])
+    if citations:
+        plan.citations = citations
+        plan.grounded_used = True
+
+    audit: Dict[str, Any] = {
+        "agent_backend": "langgraph",
+        "agent_tool_calls": int(final.get("tool_calls", 0)),
+        "llm_provider": final.get("llm_provider"),
+        "llm_model": final.get("llm_model"),
+        "llm_tokens_prompt": int(final.get("tokens_prompt", 0)),
+        "llm_tokens_completion": int(final.get("tokens_completion", 0)),
+        "llm_cost_usd": float(final.get("cost_usd", 0.0)),
+        # Memory integration is builtin-only for now (see ADR 0007).
+        "memory_short_reads": 0,
+        "memory_short_writes": 0,
+        "memory_short_pruned": 0,
+        "summary_updated": False,
+        "memory_long_reads": 0,
+        "memory_long_writes": 0,
+        "memory_long_pruned": 0,
+    }
+    _logger.info(
+        "langgraph architect run",
+        extra={"extra": {"tool_calls": audit["agent_tool_calls"]}},
+    )
+    return plan, audit

--- a/docs/adr/0007-langgraph-architect.md
+++ b/docs/adr/0007-langgraph-architect.md
@@ -1,0 +1,42 @@
+# ADR 0007: LangGraph tool-loop architect behind AGENT_BACKEND
+
+Date: 2026-07-04
+
+Status: Accepted
+
+Context
+- The "architect agent" was a deterministic linear chain (memory →
+  retrieval → single LLM call → parse), not an agent: the model never
+  decides anything about control flow. ADR-0004 posed the choice for row F:
+  rename honestly, or build a real agent. The decision (2026-07-01) was to
+  build the real agent while keeping the deterministic path.
+- LangGraph is the production standard for agent loops in 2026 and we
+  already carry `langchain-core`; a hand-rolled while-loop would re-implement
+  state routing, checkpointing hooks, and conditional edges for no benefit
+  (build-vs-buy: the library wins on its own claim here).
+
+Decision
+- Add `app/services/langgraph_architect.py`: a `StateGraph` with an `agent`
+  node (LLM decides: call a tool or finalize) and a `tools` node
+  (`retrieve_docs` via `doc_retriever`, so the vector backend applies when
+  enabled), connected by conditional edges; capped at 3 tool calls.
+- The LLM speaks a strict JSON action protocol; non-protocol replies become
+  the final summary instead of failing the run (important for weak/stub
+  models).
+- `AGENT_BACKEND=langgraph` opts in; `builtin` remains the default. The
+  dispatcher lives at the top of `run_architect_agent`, so all call sites
+  (`/architect`, `/architect/stream`, `/think`) get the flag for free, and
+  any LangGraph failure falls back to the builtin planner.
+- Audit gains `agent_backend` (which path actually ran) and
+  `agent_tool_calls`; tokens/cost accumulate across loop turns via the
+  LiteLLM client (ADR 0006 seam).
+
+Consequences
+- The repo's "agent" claim is now real: model-driven control flow with tool
+  feedback, observable in the audit trail.
+- Memory read/write integration remains builtin-only in this iteration;
+  wiring it into the graph is a natural follow-up node.
+- Tests script the LLM turns, so the loop, the cap, grounding, fallback,
+  and cost accumulation are all covered offline and deterministically.
+- New dependency: `langgraph>=1.0.0` (verified against 1.2.7 with
+  langchain-core 1.4.8).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,5 +1,25 @@
 # Agents
 
+## Architect backends (AGENT_BACKEND)
+
+The `/architect` endpoints run one of two backends, selected by
+`AGENT_BACKEND`:
+
+- **`builtin` (default).** Deterministic linear pipeline in
+  `app/services/architect_agent.py`: memory read → retrieval → one LLM call
+  with `PydanticOutputParser` format instructions → validated
+  `ArchitectPlan` → memory write. Fully offline with the stub LLM; this is
+  what tests and CI exercise.
+- **`langgraph`.** Real tool-loop agent in
+  `app/services/langgraph_architect.py`: a LangGraph `StateGraph` where the
+  LLM decides each turn whether to call the `retrieve_docs` tool (backed by
+  `doc_retriever`, so `RAG_BACKEND=vector` applies) or finalize the plan.
+  Tool observations feed back into the next turn; the loop is capped at 3
+  tool calls. Tokens and cost accumulate across turns into the audit, which
+  also reports `agent_backend` and `agent_tool_calls`. Any failure falls
+  back to the builtin planner. Memory read/write integration is
+  builtin-only for now (ADR 0007).
+
 Architect agent and community loop
 - The Architect agent can propose features when it detects gaps between a user goal and current capabilities (e.g., a new endpoint or a router rule).
 - Users can copy the proposal (summary, steps, flags) into a GitHub issue; see docs/llm_agent_streaming_prompts.md for a ready-to-use prompt set.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "sentence-transformers==3.0.1",
   "openai>=1.51.2",
   "litellm>=1.90.0",
+  "langgraph>=1.0.0",
   "langchain-core>=0.1.27",
   "pymupdf>=1.24.9",
   "mlflow>=2.15.0",

--- a/tests/test_langgraph_architect.py
+++ b/tests/test_langgraph_architect.py
@@ -1,0 +1,124 @@
+"""LangGraph tool-loop agent (AGENT_BACKEND=langgraph)."""
+
+import json
+
+from app.services import llm_client as llm_mod
+from app.services.architect_agent import run_architect_agent
+
+
+def _scripted_llm(responses):
+    """Return a fake LLMClient.call that plays back scripted texts."""
+    it = iter(responses)
+
+    def _call(self, messages, model=None, **kwargs):
+        return {
+            "text": next(it),
+            "provider": "scripted",
+            "model": "unit-test",
+            "tokens_prompt": 10,
+            "tokens_completion": 5,
+            "cost_usd": 0.001,
+        }
+
+    return _call
+
+
+def test_langgraph_tool_loop_retrieves_then_finalizes(monkeypatch, tmp_path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "rbac.txt").write_text(
+        "RBAC roles are parsed from the X-User-Role header and gate grounded queries."
+    )
+    monkeypatch.setenv("DOCS_PATH", str(docs))
+    monkeypatch.setenv("AGENT_BACKEND", "langgraph")
+
+    monkeypatch.setattr(
+        llm_mod.LLMClient,
+        "call",
+        _scripted_llm(
+            [
+                json.dumps({"action": "retrieve_docs", "query": "RBAC roles"}),
+                json.dumps(
+                    {
+                        "action": "final",
+                        "summary": "Use header-based RBAC.",
+                        "suggested_steps": ["parse role header", "gate grounded"],
+                        "suggested_env_flags": ["RBAC_ENABLED"],
+                    }
+                ),
+            ]
+        ),
+    )
+
+    plan, audit = run_architect_agent("How does RBAC work?")
+
+    assert audit["agent_backend"] == "langgraph"
+    assert audit["agent_tool_calls"] == 1
+    assert plan.summary == "Use header-based RBAC."
+    assert plan.suggested_steps == ["parse role header", "gate grounded"]
+    assert plan.grounded_used is True
+    assert any("rbac" in (c.get("source") or "").lower() for c in plan.citations)
+    # token/cost accounting accumulates across both LLM turns
+    assert audit["llm_tokens_prompt"] == 20
+    assert abs(audit["llm_cost_usd"] - 0.002) < 1e-9
+
+
+def test_langgraph_finalizes_without_tools(monkeypatch):
+    monkeypatch.setenv("AGENT_BACKEND", "langgraph")
+    monkeypatch.setattr(
+        llm_mod.LLMClient,
+        "call",
+        _scripted_llm([json.dumps({"action": "final", "summary": "Direct answer."})]),
+    )
+
+    plan, audit = run_architect_agent("Simple question")
+    assert audit["agent_backend"] == "langgraph"
+    assert audit["agent_tool_calls"] == 0
+    assert plan.summary == "Direct answer."
+    assert plan.grounded_used is False
+
+
+def test_langgraph_non_protocol_reply_becomes_summary(monkeypatch):
+    # A model that ignores the JSON protocol still yields a plan, not a crash.
+    monkeypatch.setenv("AGENT_BACKEND", "langgraph")
+    monkeypatch.setattr(
+        llm_mod.LLMClient, "call", _scripted_llm(["Just some prose answer."])
+    )
+
+    plan, audit = run_architect_agent("Whatever")
+    assert audit["agent_backend"] == "langgraph"
+    assert plan.summary == "Just some prose answer."
+
+
+def test_langgraph_tool_call_cap(monkeypatch, tmp_path):
+    # The agent keeps asking for tools; the loop must stop at the cap.
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.txt").write_text("alpha beta gamma")
+    monkeypatch.setenv("DOCS_PATH", str(docs))
+    monkeypatch.setenv("AGENT_BACKEND", "langgraph")
+
+    endless = [json.dumps({"action": "retrieve_docs", "query": "alpha"})] * 10
+    monkeypatch.setattr(llm_mod.LLMClient, "call", _scripted_llm(endless))
+
+    plan, audit = run_architect_agent("Loop forever?")
+    assert audit["agent_backend"] == "langgraph"
+    assert audit["agent_tool_calls"] == 3  # MAX_TOOL_CALLS
+
+
+def test_default_backend_is_builtin(monkeypatch):
+    monkeypatch.delenv("AGENT_BACKEND", raising=False)
+    plan, audit = run_architect_agent("What is this project?")
+    assert audit["agent_backend"] == "builtin"
+
+
+def test_langgraph_failure_falls_back_to_builtin(monkeypatch):
+    monkeypatch.setenv("AGENT_BACKEND", "langgraph")
+    import app.services.langgraph_architect as lg
+
+    def _boom(*a, **k):
+        raise RuntimeError("graph exploded")
+
+    monkeypatch.setattr(lg, "run_langgraph_architect", _boom)
+    plan, audit = run_architect_agent("Resilience check")
+    assert audit["agent_backend"] == "builtin"


### PR DESCRIPTION
## What

Row F of [docs/MODERNIZATION_PLAN.md](../blob/main/docs/MODERNIZATION_PLAN.md), the last core row: a real LangGraph tool-loop agent behind `AGENT_BACKEND`, with the deterministic builtin planner staying the default. This resolves the decision locked in ADR-0004: build the real agent rather than rename the linear chain.

## Changes

- **`app/services/langgraph_architect.py` (new):** `StateGraph` with an `agent` node (LLM chooses: `retrieve_docs` or `final` via a strict JSON action protocol) and a `tools` node (retrieval through `doc_retriever`, so `RAG_BACKEND=vector` applies). Conditional edges loop observations back to the agent; hard cap of 3 tool calls. Non-protocol LLM replies become the final summary instead of crashing the run.
- **Dispatch:** top of `run_architect_agent`, so `/architect`, `/architect/stream`, and `/think` all honor the flag with zero call-site changes. Any LangGraph failure falls back to the builtin planner.
- **Audit:** new `agent_backend` (which path actually ran) and `agent_tool_calls` fields; tokens and `cost_usd` accumulate across loop turns through the LiteLLM client from row E.
- **Docs:** `agents.md` backend section, ADR 0007, CHANGELOG. Dependency `langgraph>=1.0.0` (verified on 1.2.7 against langchain-core 1.4.8).

## Tests (6 new, tests/test_langgraph_architect.py)

Scripted LLM turns make the loop fully deterministic and offline: tool-then-final flow (citations grounded, tokens/cost summed across turns), finalize-without-tools, non-protocol reply handling, the 3-call cap against an endless-tool model, builtin as default, and builtin fallback when the graph throws.

## Verification

Full suite 124 passed locally, `ruff check` clean, no OpenAPI drift.

Memory read/write stays builtin-only this iteration (noted in ADR 0007) — wiring it as a graph node is the natural follow-up. Core queue A–F is complete with this PR; G (MCP server), H (Presidio), I (coverage gate) remain optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)