### PR TITLE
feat: MCP server exposing architect capabilities (plan row G)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* MCP server (`app/mcp_server.py`, console script `ai-architect-mcp`): exposes `retrieve_docs`, `detect_pii`, and `architect_plan` over the Model Context Protocol via the official SDK's FastMCP on stdio; backend flags (`RAG_BACKEND`, `AGENT_BACKEND`, `LLM_PROVIDER`) apply unchanged and audit metadata rides along in tool results (`docs/adr/0008-mcp-server.md`).
+
 * Real LangGraph tool-loop architect behind `AGENT_BACKEND=langgraph` (`app/services/langgraph_architect.py`): the LLM decides per turn between calling `retrieve_docs` (via `doc_retriever`, vector backend applies) and finalizing; capped at 3 tool calls; tokens/cost accumulate across turns; audit reports `agent_backend` and `agent_tool_calls`. The deterministic builtin planner stays the default and the fallback on any failure (`docs/adr/0007-langgraph-architect.md`).
 
 * LiteLLM-backed `LLMClient`: all real providers route through `litellm.completion` (the hand-rolled openai/openrouter/azure branches are gone); the deterministic offline `stub` provider stays the default and the fallback on any provider error. `cost_usd` is now real, from LiteLLM's per-model pricing map, and `app/utils/cost.py` prices its estimates from the same map (static table only as fallback). Tests: `tests/test_llm_cost.py`.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ curl -sX POST localhost:8000/architect \
 **UI:** http://localhost:8000/architect/ui
 Note: /architect is feature-gated. Ensure PROJECT_GUIDE_ENABLED=true (in .env or environment) before calling it.
 
+**MCP:** the same capabilities are exposed over the Model Context Protocol
+for Claude Desktop / Claude Code / any MCP client — tools `architect_plan`,
+`retrieve_docs`, `detect_pii`:
+
+```bash
+ai-architect-mcp        # stdio server (or: python -m app.mcp_server)
+```
+
+Backend flags apply unchanged (`RAG_BACKEND`, `AGENT_BACKEND`,
+`LLM_PROVIDER`). See [ADR-0008](docs/adr/0008-mcp-server.md).
+
 ---
 
 ## 🧱 Repository Layout
@@ -184,8 +195,9 @@ Full details → `docs/observability.md`, `docs/security.md`
 | 3–4 | Orchestration (deterministic planner), RBAC, Grafana, Deploy Recipes | ✅ Done |
 | 5–6 | PII detection, Risk ML integration, Router v2 | 🚧 In Progress |
 | 7–8 | Memory (short + long term) | ✅ Done |
-| 9 | Architect agent on LangGraph | 🧩 Planned |
-| 10+ | Real vector retrieval, LiteLLM cost tracking, MCP surface | 🧩 Planned |
+| 9 | Architect agent on LangGraph (`AGENT_BACKEND=langgraph`) | ✅ Done |
+| 10 | Real vector retrieval (`RAG_BACKEND=vector`), LiteLLM cost tracking, MCP server | ✅ Done |
+| 11+ | Presidio PII backend, coverage gate, Pinecone backend | 🧩 Planned |
 
 > Full roadmap and build-vs-buy rationale: [docs/MODERNIZATION_PLAN.md](docs/MODERNIZATION_PLAN.md), [ADR-0004](docs/adr/0004-build-vs-buy.md).
 

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -1,0 +1,66 @@
+"""MCP server exposing AI-Architect capabilities over the Model Context Protocol.
+
+Run over stdio (for Claude Desktop / Claude Code / any MCP client):
+
+    python -m app.mcp_server
+
+Tools map onto the same service layer the HTTP API uses, so backend flags
+apply unchanged: RAG_BACKEND selects keyword scan vs Chroma vector
+retrieval, AGENT_BACKEND selects the builtin planner vs the LangGraph
+tool-loop agent, and LLM_PROVIDER=stub keeps everything offline.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP(
+    "ai-architect",
+    instructions=(
+        "AI-Architect reference platform: grounded document retrieval, "
+        "PII detection, and an architecture-planning agent with audit "
+        "metadata (tokens, cost, backends)."
+    ),
+)
+
+
+@mcp.tool()
+def retrieve_docs(query: str, k: int = 3) -> Dict[str, Any]:
+    """Retrieve documentation citations for a query.
+
+    Uses the configured retrieval backend (RAG_BACKEND: keyword_scan or
+    vector) and returns an extractive answer plus source citations.
+    """
+    from app.services.doc_retriever import answer_with_citations
+
+    return answer_with_citations(query, k=k)
+
+
+@mcp.tool()
+def detect_pii(text: str, types: Optional[List[str]] = None) -> Dict[str, Any]:
+    """Detect PII entities (emails, phones, ids, ...) in the given text."""
+    from app.services.pii_detector import detect_pii as _detect
+
+    return _detect(text, types=types)
+
+
+@mcp.tool()
+def architect_plan(question: str) -> Dict[str, Any]:
+    """Produce an architecture plan for the question.
+
+    Runs the architect agent (AGENT_BACKEND: builtin planner or LangGraph
+    tool-loop) and returns the plan plus audit metadata including
+    agent_backend, token counts, and real cost_usd.
+    """
+    from app.services.architect_agent import run_architect_agent
+
+    plan, audit = run_architect_agent(question)
+    return {"plan": plan.model_dump(), "audit": audit}
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/adr/0008-mcp-server.md
+++ b/docs/adr/0008-mcp-server.md
@@ -1,0 +1,40 @@
+# ADR 0008: Expose architect capabilities over MCP
+
+Date: 2026-07-04
+
+Status: Accepted
+
+Context
+- ADR-0004 identified MCP as the connective tissue of the 2026 agent
+  ecosystem and the highest-signal gap in this repo: every capability was
+  reachable only through the bespoke HTTP API, so agent hosts (Claude
+  Desktop/Code, MCP-aware IDEs, other agent runtimes) could not consume it
+  without custom glue.
+- The service layer is already cleanly separated from the routers
+  (doc_retriever, pii_detector, architect_agent), so an MCP surface can sit
+  beside FastAPI without touching request handling.
+
+Decision
+- Add `app/mcp_server.py` using the official `mcp` SDK's FastMCP, run over
+  stdio via the `ai-architect-mcp` console script (or
+  `python -m app.mcp_server`).
+- Expose three tools mapping 1:1 onto the service layer: `retrieve_docs`
+  (doc_retriever, so `RAG_BACKEND` keyword/vector applies), `detect_pii`,
+  and `architect_plan` (run_architect_agent, so `AGENT_BACKEND`
+  builtin/langgraph applies and the audit with agent_backend, tokens, and
+  real cost_usd rides along in the tool result).
+- Buy-over-build: the SDK owns transport, protocol negotiation, and schema
+  generation from type hints; the repo contributes only the tool bodies.
+- Tests use the SDK's in-memory connected client/server session, so the
+  full MCP round-trip (list_tools, call_tool, error surfacing) is covered
+  offline with no subprocess.
+
+Consequences
+- Any MCP client can now call the platform's governed capabilities; audit
+  metadata travels with results, keeping the FinOps/observability story
+  intact outside HTTP.
+- New dependency `mcp>=1.20.0` (verified against 1.28.1).
+- RBAC is not enforced on the MCP surface in this iteration: stdio servers
+  inherit the trust of the host process. Role-scoped MCP (e.g. via an
+  authenticated HTTP transport) is follow-up work if the surface is ever
+  exposed beyond the local host.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "openai>=1.51.2",
   "litellm>=1.90.0",
   "langgraph>=1.0.0",
+  "mcp>=1.20.0",
   "langchain-core>=0.1.27",
   "pymupdf>=1.24.9",
   "mlflow>=2.15.0",
@@ -40,6 +41,10 @@ dependencies = [
   "pandas>=2.2.0",  "jinja2>=3.1.4",
   "PyYAML>=6.0",
 ]
+
+
+[project.scripts]
+ai-architect-mcp = "app.mcp_server:main"
 
 
 [tool.ruff]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,106 @@
+"""MCP server: tools exposed over a real in-memory MCP client session."""
+
+import json
+
+import anyio
+import pytest
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from app.mcp_server import mcp
+
+
+def _run(coro_fn):
+    return anyio.run(coro_fn)
+
+
+def test_mcp_lists_expected_tools():
+    async def _t():
+        async with create_connected_server_and_client_session(
+            mcp._mcp_server
+        ) as client:
+            tools = await client.list_tools()
+            return sorted(t.name for t in tools.tools)
+
+    names = _run(_t)
+    assert names == ["architect_plan", "detect_pii", "retrieve_docs"]
+
+
+def test_mcp_retrieve_docs_returns_citations(monkeypatch, tmp_path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "gdpr.txt").write_text("GDPR governs data protection in the EU.")
+    monkeypatch.setenv("DOCS_PATH", str(docs))
+    monkeypatch.delenv("RAG_BACKEND", raising=False)
+
+    async def _t():
+        async with create_connected_server_and_client_session(
+            mcp._mcp_server
+        ) as client:
+            res = await client.call_tool(
+                "retrieve_docs", {"query": "GDPR data protection", "k": 2}
+            )
+            return json.loads(res.content[0].text)
+
+    out = _run(_t)
+    assert out["rag_backend"] == "keyword_scan"
+    assert out["citations"]
+    assert out["citations"][0]["source"] == "gdpr.txt"
+    assert out["answer"].startswith("Extracted from matching documents:")
+
+
+def test_mcp_detect_pii():
+    async def _t():
+        async with create_connected_server_and_client_session(
+            mcp._mcp_server
+        ) as client:
+            res = await client.call_tool(
+                "detect_pii", {"text": "Contact john@example.com please"}
+            )
+            return json.loads(res.content[0].text)
+
+    out = _run(_t)
+    assert out["total"] >= 1
+    assert "email" in {e.get("type") for e in out.get("entities", [])}
+
+
+def test_mcp_architect_plan_includes_audit(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "stub")
+    monkeypatch.delenv("AGENT_BACKEND", raising=False)
+
+    async def _t():
+        async with create_connected_server_and_client_session(
+            mcp._mcp_server
+        ) as client:
+            res = await client.call_tool(
+                "architect_plan", {"question": "How should I add RBAC?"}
+            )
+            return json.loads(res.content[0].text)
+
+    out = _run(_t)
+    assert "plan" in out and "audit" in out
+    assert out["audit"]["agent_backend"] == "builtin"
+    assert "llm_cost_usd" in out["audit"]
+
+
+def test_mcp_tool_error_is_reported(monkeypatch):
+    # A tool raising inside the server must surface as an MCP tool error,
+    # not a transport crash.
+    import app.services.pii_detector as pii
+
+    def _boom(*a, **k):
+        raise RuntimeError("detector down")
+
+    monkeypatch.setattr(pii, "detect_pii", _boom)
+
+    async def _t():
+        async with create_connected_server_and_client_session(
+            mcp._mcp_server
+        ) as client:
+            return await client.call_tool("detect_pii", {"text": "x"})
+
+    res = _run(_t)
+    assert res.isError is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])


### PR DESCRIPTION
## What

Row G of [docs/MODERNIZATION_PLAN.md](../blob/main/docs/MODERNIZATION_PLAN.md): expose the platform's capabilities over the Model Context Protocol. ADR-0004 called MCP the highest-signal gap in the repo — every capability was locked behind the bespoke HTTP API.

## Changes

- **`app/mcp_server.py` (new):** official `mcp` SDK FastMCP over stdio, console script `ai-architect-mcp` (also `python -m app.mcp_server`). Three tools mapping 1:1 onto the service layer:
  - `retrieve_docs` → doc_retriever (`RAG_BACKEND` keyword/vector applies)
  - `detect_pii` → pii_detector
  - `architect_plan` → run_architect_agent (`AGENT_BACKEND` builtin/langgraph applies; audit with `agent_backend`, tokens, and real `cost_usd` returns inside the tool result)
- **Buy-over-build:** the SDK owns transport/protocol/schema-from-type-hints; the repo contributes only tool bodies. Dependency `mcp>=1.20.0` (verified on 1.28.1).
- **Docs:** ADR 0008, README MCP quickstart, roadmap table refreshed (rows 9/10 were still 'Planned' despite shipping this week).
- RBAC note: stdio inherits host-process trust; role-scoped MCP is documented follow-up in the ADR.

## Tests (5 new, tests/test_mcp_server.py)

Run through the SDK's in-memory connected client/server session — a real MCP round-trip, offline: tool listing, retrieval citations via MCP, PII detection, plan+audit shape, and tool-exception surfacing as MCP tool errors.

## Verification

Full suite 129 passed locally, `ruff check` clean, no OpenAPI drift, console script verified on a fresh `pip install -e .`.

Remaining optional rows: H (Presidio PII backend), I (coverage gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)