### PR TITLE
feat: Presidio PII backend behind PII_BACKEND (plan row H)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* Presidio PII backend behind `PII_BACKEND=presidio` (`app/services/pii_presidio.py`): NER + pattern recognizers with per-entity confidence scores (`PII_PRESIDIO_THRESHOLD`, `PII_SPACY_MODEL`); optional install via `pip install .[presidio]`; regex baseline stays the default and the fallback, and results report `pii_backend` = backend actually used (`docs/adr/0009-presidio-pii-backend.md`).
+
 * MCP server (`app/mcp_server.py`, console script `ai-architect-mcp`): exposes `retrieve_docs`, `detect_pii`, and `architect_plan` over the Model Context Protocol via the official SDK's FastMCP on stdio; backend flags (`RAG_BACKEND`, `AGENT_BACKEND`, `LLM_PROVIDER`) apply unchanged and audit metadata rides along in tool results (`docs/adr/0008-mcp-server.md`).
 
 * Real LangGraph tool-loop architect behind `AGENT_BACKEND=langgraph` (`app/services/langgraph_architect.py`): the LLM decides per turn between calling `retrieve_docs` (via `doc_retriever`, vector backend applies) and finalizing; capped at 3 tool calls; tokens/cost accumulate across turns; audit reports `agent_backend` and `agent_tool_calls`. The deterministic builtin planner stays the default and the fallback on any failure (`docs/adr/0007-langgraph-architect.md`).

--- a/app/services/pii_detector.py
+++ b/app/services/pii_detector.py
@@ -108,6 +108,19 @@ def _compile_active_patterns(types_override: list[str] | None = None, locales_ov
 
 
 def detect_pii(text: str, types: list[str] | None = None, locales: list[str] | None = None) -> Dict[str, Any]:
+    # Optional Presidio backend (PII_BACKEND=presidio); the regex baseline
+    # below stays the default and the fallback when Presidio is not
+    # installed or fails (e.g. missing spaCy model).
+    if os.getenv("PII_BACKEND", "regex").lower() == "presidio":
+        try:
+            from app.services.pii_presidio import detect_pii_presidio
+
+            result = detect_pii_presidio(text, types=types)
+            result["pii_backend"] = "presidio"
+            return result
+        except Exception:
+            pass
+
     entities: List[Dict[str, Any]] = []
     counts: Dict[str, int] = {}
 
@@ -139,4 +152,5 @@ def detect_pii(text: str, types: list[str] | None = None, locales: list[str] | N
         "types_present": types_present,
         "counts": counts,
         "total": len(entities),
+        "pii_backend": "regex",
     }

--- a/app/services/pii_presidio.py
+++ b/app/services/pii_presidio.py
@@ -1,0 +1,104 @@
+"""Presidio-backed PII detection (PII_BACKEND=presidio).
+
+Optional backend using Microsoft Presidio's AnalyzerEngine (NER +
+pattern recognizers) instead of the regex baseline. Returns the same
+shape as pii_detector.detect_pii. Presidio is an optional dependency
+(`pip install .[presidio]` plus a spaCy model); the caller falls back to
+the regex baseline when it is unavailable or fails.
+"""
+
+import os
+from functools import lru_cache
+from typing import Any, Dict, List, Optional
+
+# Our type names -> Presidio entity names
+TYPE_TO_PRESIDIO = {
+    "email": "EMAIL_ADDRESS",
+    "phone": "PHONE_NUMBER",
+    "ssn": "US_SSN",
+    "credit_card": "CREDIT_CARD",
+    "iban": "IBAN_CODE",
+    "ipv4": "IP_ADDRESS",
+    "ipv6": "IP_ADDRESS",
+    "passport": "US_PASSPORT",
+    "person": "PERSON",
+    "location": "LOCATION",
+}
+PRESIDIO_TO_TYPE = {
+    "EMAIL_ADDRESS": "email",
+    "PHONE_NUMBER": "phone",
+    "US_SSN": "ssn",
+    "CREDIT_CARD": "credit_card",
+    "IBAN_CODE": "iban",
+    "IP_ADDRESS": "ipv4",
+    "US_PASSPORT": "passport",
+    "PERSON": "person",
+    "LOCATION": "location",
+}
+
+
+def _threshold() -> float:
+    try:
+        return float(os.getenv("PII_PRESIDIO_THRESHOLD", "0.5"))
+    except Exception:
+        return 0.5
+
+
+@lru_cache(maxsize=1)
+def _analyzer():
+    """Build the AnalyzerEngine once; spaCy model via PII_SPACY_MODEL."""
+    from presidio_analyzer import AnalyzerEngine
+    from presidio_analyzer.nlp_engine import NlpEngineProvider
+
+    model = os.getenv("PII_SPACY_MODEL", "en_core_web_sm")
+    provider = NlpEngineProvider(
+        nlp_configuration={
+            "nlp_engine_name": "spacy",
+            "models": [{"lang_code": "en", "model_name": model}],
+        }
+    )
+    return AnalyzerEngine(nlp_engine=provider.create_engine())
+
+
+def detect_pii_presidio(
+    text: str, types: Optional[List[str]] = None
+) -> Dict[str, Any]:
+    """Analyze text with Presidio; same return shape as the regex baseline.
+
+    Raises on any Presidio/spaCy failure; the dispatcher in pii_detector
+    handles the fallback.
+    """
+    from app.services.pii_detector import _mask
+
+    sample = (text or "")[:5000]
+    wanted = None
+    if types:
+        wanted = sorted(
+            {TYPE_TO_PRESIDIO[t] for t in types if t in TYPE_TO_PRESIDIO}
+        )
+
+    results = _analyzer().analyze(text=sample, language="en", entities=wanted)
+
+    threshold = _threshold()
+    entities: List[Dict[str, Any]] = []
+    counts: Dict[str, int] = {}
+    for r in results:
+        if r.score < threshold:
+            continue
+        ptype = PRESIDIO_TO_TYPE.get(r.entity_type, r.entity_type.lower())
+        counts[ptype] = counts.get(ptype, 0) + 1
+        entities.append(
+            {
+                "type": ptype,
+                "value_preview": _mask(sample[r.start : r.end]),
+                "span": [r.start, r.end],
+                "score": round(float(r.score), 3),
+            }
+        )
+
+    return {
+        "entities": entities,
+        "types_present": sorted(counts.keys()),
+        "counts": counts,
+        "total": len(entities),
+    }

--- a/docs/adr/0009-presidio-pii-backend.md
+++ b/docs/adr/0009-presidio-pii-backend.md
@@ -1,0 +1,39 @@
+# ADR 0009: Presidio PII backend behind PII_BACKEND; regex baseline kept
+
+Date: 2026-07-04
+
+Status: Accepted
+
+Context
+- The PII detector is hand-rolled regex/heuristics: deterministic, offline,
+  and fine as a baseline, but pattern-only detection misses contextual
+  entities (names, locations) and produces locale false positives.
+  ADR-0004's build-vs-buy matrix marked this as a place where a library
+  wins on its own claim: Presidio combines NER with curated pattern
+  recognizers and confidence scores.
+- Presidio pulls spaCy plus a language model, which is far too heavy to
+  force on every install or on CI.
+
+Decision
+- Add `app/services/pii_presidio.py` behind `PII_BACKEND=presidio`; the
+  regex baseline stays the default and the fallback whenever Presidio is
+  unavailable or errors (missing package, missing spaCy model, runtime
+  failure). Results report `pii_backend` = backend actually used.
+- Presidio is an optional dependency extra (`pip install .[presidio]`),
+  keeping core installs and CI light. The spaCy model is configurable via
+  `PII_SPACY_MODEL` (default en_core_web_sm); confidence cutoff via
+  `PII_PRESIDIO_THRESHOLD` (default 0.5).
+- Both backends return the same shape (entities with type, masked
+  value_preview, span; counts; types_present; total); Presidio entities add
+  `score`. Type filters translate to Presidio entity names
+  (email→EMAIL_ADDRESS, ...), so `/pii` request-level filtering works
+  unchanged.
+
+Consequences
+- Production deployments can opt into NER-grade detection without any test
+  or CI dependency on model downloads: tests exercise the mapping,
+  threshold, and type translation through a scripted fake Presidio, and
+  the fallback path is tested by blocking the import.
+- Locale-specific regex patterns (PII_LOCALES) remain regex-backend-only;
+  Presidio has its own recognizer registry, and extending it is follow-up
+  work if needed.

--- a/docs/pii.md
+++ b/docs/pii.md
@@ -1,11 +1,25 @@
 # PII detection and configuration
 
-This project includes a simple, deterministic PII detector based on regex and heuristics. It returns masked previews, counts, and a list of detected types without external calls.
+Two detection backends, selected by `PII_BACKEND`:
+
+- **`regex` (default).** Simple, deterministic detector based on regex and
+  heuristics. Masked previews, counts, and detected types, no external
+  calls; this is what tests and CI exercise.
+- **`presidio`.** Microsoft Presidio's AnalyzerEngine (NER + pattern
+  recognizers) in `app/services/pii_presidio.py`, same result shape plus a
+  per-entity `score`. Optional install: `pip install .[presidio]` and a
+  spaCy model (`python -m spacy download en_core_web_sm`; override with
+  `PII_SPACY_MODEL`). Confidence cutoff via `PII_PRESIDIO_THRESHOLD`
+  (default 0.5). If Presidio is missing or fails, detection falls back to
+  the regex baseline; results report `pii_backend` = backend actually used.
 
 Environment variables
+- PII_BACKEND: regex (default) | presidio
+- PII_PRESIDIO_THRESHOLD: minimum Presidio confidence score (default 0.5)
+- PII_SPACY_MODEL: spaCy model for the Presidio NLP engine (default en_core_web_sm)
 - PII_TYPES: comma-separated base types to enable. Default: email,phone,ssn,credit_card,ipv4
   - Additional base types available: ipv6, iban, passport
-- PII_LOCALES: comma-separated locales to enable locale-specific patterns (e.g., US,UK,CA,DE)
+- PII_LOCALES: comma-separated locales to enable locale-specific patterns (e.g., US,UK,CA,DE); regex backend only
 
 Request-level filtering
 - The /pii endpoint accepts an optional types array in the request body to override enabled base types for that request only (e.g., ["ssn"]). Locales remain configured via PII_LOCALES.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ dependencies = [
 ]
 
 
+[project.optional-dependencies]
+presidio = ["presidio-analyzer>=2.2"]
+
+
 [project.scripts]
 ai-architect-mcp = "app.mcp_server:main"
 

--- a/tests/test_pii_presidio.py
+++ b/tests/test_pii_presidio.py
@@ -1,0 +1,125 @@
+"""Presidio PII backend (PII_BACKEND=presidio) and its regex fallback."""
+
+import sys
+import types
+
+from app.services.pii_detector import detect_pii
+
+
+class _FakeResult:
+    def __init__(self, entity_type, start, end, score):
+        self.entity_type = entity_type
+        self.start = start
+        self.end = end
+        self.score = score
+
+
+def _install_fake_presidio(monkeypatch, results):
+    """Inject fake presidio_analyzer modules returning scripted results."""
+
+    class FakeAnalyzer:
+        def analyze(self, text, language, entities=None):
+            self.last_entities = entities
+            return results
+
+    fake_analyzer = FakeAnalyzer()
+
+    class FakeAnalyzerEngine:
+        def __init__(self, nlp_engine=None):
+            pass
+
+        def analyze(self, text, language, entities=None):
+            return fake_analyzer.analyze(text, language, entities)
+
+    class FakeProvider:
+        def __init__(self, nlp_configuration=None):
+            pass
+
+        def create_engine(self):
+            return object()
+
+    mod = types.ModuleType("presidio_analyzer")
+    mod.AnalyzerEngine = FakeAnalyzerEngine
+    nlp_mod = types.ModuleType("presidio_analyzer.nlp_engine")
+    nlp_mod.NlpEngineProvider = FakeProvider
+    monkeypatch.setitem(sys.modules, "presidio_analyzer", mod)
+    monkeypatch.setitem(sys.modules, "presidio_analyzer.nlp_engine", nlp_mod)
+
+    # the engine is cached; reset between tests
+    from app.services import pii_presidio
+
+    pii_presidio._analyzer.cache_clear()
+    return fake_analyzer
+
+
+def test_presidio_backend_maps_entities(monkeypatch):
+    text = "Mail john@example.com now"
+    monkeypatch.setenv("PII_BACKEND", "presidio")
+    _install_fake_presidio(
+        monkeypatch, [_FakeResult("EMAIL_ADDRESS", 5, 21, 0.99)]
+    )
+
+    out = detect_pii(text)
+    assert out["pii_backend"] == "presidio"
+    assert out["total"] == 1
+    e = out["entities"][0]
+    assert e["type"] == "email"
+    assert e["span"] == [5, 21]
+    assert e["score"] == 0.99
+    assert "@" not in e["value_preview"] or "*" in e["value_preview"]
+    assert out["counts"] == {"email": 1}
+
+
+def test_presidio_threshold_filters_low_scores(monkeypatch):
+    monkeypatch.setenv("PII_BACKEND", "presidio")
+    monkeypatch.setenv("PII_PRESIDIO_THRESHOLD", "0.8")
+    _install_fake_presidio(
+        monkeypatch,
+        [
+            _FakeResult("EMAIL_ADDRESS", 0, 5, 0.95),
+            _FakeResult("PERSON", 6, 10, 0.4),
+        ],
+    )
+
+    out = detect_pii("abcde fghi")
+    assert out["total"] == 1
+    assert out["types_present"] == ["email"]
+
+
+def test_presidio_types_filter_translates_to_entities(monkeypatch):
+    monkeypatch.setenv("PII_BACKEND", "presidio")
+    fake = _install_fake_presidio(
+        monkeypatch, [_FakeResult("EMAIL_ADDRESS", 0, 5, 0.9)]
+    )
+
+    detect_pii("abcde", types=["email", "phone"])
+    assert fake.last_entities == ["EMAIL_ADDRESS", "PHONE_NUMBER"]
+
+
+def test_presidio_unavailable_falls_back_to_regex(monkeypatch):
+    # No fake modules installed and presidio import fails -> regex baseline.
+    monkeypatch.setenv("PII_BACKEND", "presidio")
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_presidio(name, *a, **k):
+        if name.startswith("presidio_analyzer"):
+            raise ImportError("presidio not installed")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _no_presidio)
+    from app.services import pii_presidio
+
+    pii_presidio._analyzer.cache_clear()
+
+    out = detect_pii("Contact john@example.com")
+    assert out["pii_backend"] == "regex"
+    assert out["counts"].get("email") == 1
+
+
+def test_default_backend_is_regex(monkeypatch):
+    monkeypatch.delenv("PII_BACKEND", raising=False)
+    out = detect_pii("Contact john@example.com")
+    assert out["pii_backend"] == "regex"
+    assert out["total"] >= 1


### PR DESCRIPTION
## What

Row H of [docs/MODERNIZATION_PLAN.md](../blob/main/docs/MODERNIZATION_PLAN.md): Presidio detector behind a flag, regex baseline kept.

## Changes

- **`app/services/pii_presidio.py` (new):** Presidio `AnalyzerEngine` behind `PII_BACKEND=presidio`. Same result shape as the regex detector (masked previews, spans, counts) plus per-entity `score`; confidence cutoff `PII_PRESIDIO_THRESHOLD` (default 0.5); spaCy model `PII_SPACY_MODEL` (default en_core_web_sm). Our type names translate to Presidio entities, so `/pii` request-level type filtering works unchanged.
- **Dispatch + fallback:** regex remains the default; any Presidio failure (not installed, missing model, runtime error) falls back to regex. Results now report `pii_backend` = backend actually used.
- **Packaging:** Presidio ships as an optional extra (`pip install .[presidio]`), so core installs and CI never pull spaCy or models.
- **Docs:** `pii.md` backend section, ADR 0009, CHANGELOG.

## Tests (5 new, tests/test_pii_presidio.py)

All offline via a scripted fake Presidio: entity mapping + masking + score, threshold filtering, type-filter translation to Presidio entity names, import-blocked fallback to regex, and regex-as-default. Existing PII suites (shape, endpoint, locales, remediation) untouched and passing.

## Verification

Full suite 134 passed locally, `ruff check` clean, no OpenAPI drift.

Last optional row after this: I (coverage gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)