### PR TITLE
ci: enforce 75% coverage gate (plan row I)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
         run: |
           . .venv/bin/activate
           ruff check .
-      - name: Run tests
+      - name: Run tests (coverage gate ≥75%)
         run: |
           . .venv/bin/activate
-          pytest -q
+          pytest -q --cov=app --cov=scripts --cov-report=term --cov-fail-under=75
       - name: Export OpenAPI
         run: |
           . .venv/bin/activate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* CI coverage gate: tests run with `pytest-cov` and fail under 75% line coverage (current baseline: 79%); coverage config in `pyproject.toml`, gate badge in the README.
+
 * Presidio PII backend behind `PII_BACKEND=presidio` (`app/services/pii_presidio.py`): NER + pattern recognizers with per-entity confidence scores (`PII_PRESIDIO_THRESHOLD`, `PII_SPACY_MODEL`); optional install via `pip install .[presidio]`; regex baseline stays the default and the fallback, and results report `pii_backend` = backend actually used (`docs/adr/0009-presidio-pii-backend.md`).
 
 * MCP server (`app/mcp_server.py`, console script `ai-architect-mcp`): exposes `retrieve_docs`, `detect_pii`, and `architect_plan` over the Model Context Protocol via the official SDK's FastMCP on stdio; backend flags (`RAG_BACKEND`, `AGENT_BACKEND`, `LLM_PROVIDER`) apply unchanged and audit metadata rides along in tool results (`docs/adr/0008-mcp-server.md`).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-[![CI](https://github.com/bridge-intelligence-lab/ai-architect/actions/workflows/ci.yml/badge.svg)](https://github.com/bridge-intelligence-lab/ai-architect/actions/workflows/ci.yml) [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE) [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Docs](https://img.shields.io/badge/docs-index-blue)](docs/README.md)[![Ruff](https://img.shields.io/badge/lint-ruff-46aef7.svg)](https://github.com/astral-sh/ruff) [![FastAPI](https://img.shields.io/badge/FastAPI-0.115%2B-009688.svg)](https://fastapi.tiangolo.com)
+[![CI](https://github.com/bridge-intelligence-lab/ai-architect/actions/workflows/ci.yml/badge.svg)](https://github.com/bridge-intelligence-lab/ai-architect/actions/workflows/ci.yml) [![Coverage gate](https://img.shields.io/badge/coverage-%E2%89%A575%25-brightgreen.svg)](.github/workflows/ci.yml) [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE) [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Docs](https://img.shields.io/badge/docs-index-blue)](docs/README.md)[![Ruff](https://img.shields.io/badge/lint-ruff-46aef7.svg)](https://github.com/astral-sh/ruff) [![FastAPI](https://img.shields.io/badge/FastAPI-0.115%2B-009688.svg)](https://fastapi.tiangolo.com)
 
 ![Hero](docs/images/hero.png)
 
@@ -197,7 +197,8 @@ Full details → `docs/observability.md`, `docs/security.md`
 | 7–8 | Memory (short + long term) | ✅ Done |
 | 9 | Architect agent on LangGraph (`AGENT_BACKEND=langgraph`) | ✅ Done |
 | 10 | Real vector retrieval (`RAG_BACKEND=vector`), LiteLLM cost tracking, MCP server | ✅ Done |
-| 11+ | Presidio PII backend, coverage gate, Pinecone backend | 🧩 Planned |
+| 11 | Presidio PII backend, CI coverage gate | ✅ Done |
+| 12+ | Pinecone backend, role-scoped MCP, memory in the LangGraph loop | 🧩 Planned |
 
 > Full roadmap and build-vs-buy rationale: [docs/MODERNIZATION_PLAN.md](docs/MODERNIZATION_PLAN.md), [ADR-0004](docs/adr/0004-build-vs-buy.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "python-multipart>=0.0.9",
   "prometheus-client>=0.20.0",
   "pytest>=8.3.0",
+  "pytest-cov>=5.0.0",
   "httpx>=0.27.0",
   "anyio>=4.4.0",
   "ruff>=0.6.5",
@@ -63,3 +64,12 @@ addopts = "--durations=15"
 faulthandler_timeout = 300
 
 
+
+
+[tool.coverage.run]
+source = ["app", "scripts"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+precision = 1
+skip_empty = true


### PR DESCRIPTION
## What

Row I of [docs/MODERNIZATION_PLAN.md](../blob/main/docs/MODERNIZATION_PLAN.md) — the final row. The CI test step now runs with `pytest-cov` and fails below **75%** line coverage.

## Details

- Baseline measured before setting the bar: **79.0%** over `app` + `scripts` (134 tests). 75% gives headroom for refactors without being toothless.
- `pytest-cov>=5.0.0` added to deps; `[tool.coverage.run]`/`[tool.coverage.report]` in `pyproject.toml` (tests omitted from measurement).
- Coverage-gate badge added to the README (static, documents the enforced floor); roadmap table updated — with this PR every row of the modernization plan (0, A–I) is shipped.

## Verification

Gate passes locally: 134 passed at 79.0% ≥ 75%. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)