### PR TITLE
fix: langgraph empty plans at tool-call cap + test .env isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
 * Deterministic `hash` embeddings provider (hashed bag-of-words) for offline golden-query tests; `EMBEDDINGS_PROVIDER=local|hash|stub`.
 * `tests/test_vector_rag.py`: golden-query ranking, determinism, vector→keyword fallback, endpoint audit reporting, and empty-corpus (no fabricated citations) contracts.
 
+### Fixed
+
+* LangGraph architect no longer returns empty plans when it hits the tool-call cap: the agent is told the retrieval budget is exhausted and must finalize; if the plan still has no summary the builtin planner takes over (found by LangSmith eval baseline: 8/18 grounded prompts affected).
+* Tests no longer inherit the developer's `.env` (loaded with `override=True` by `app/main.py` at import): an autouse fixture pins the stub provider and clears provider/tracing keys, ending silent live OpenAI calls from the suite.
+
 ### Changed
 
 * Rename `app/services/langchain_rag.py` → `app/services/doc_retriever.py`; the module is a deterministic keyword-scan retriever and never used LangChain (`docs/adr/0005-doc-retriever-naming.md`).

--- a/app/services/langgraph_architect.py
+++ b/app/services/langgraph_architect.py
@@ -69,9 +69,19 @@ def _parse_decision(text: str) -> Dict[str, Any]:
     return {"action": "final", "summary": raw[:400]}
 
 
+_BUDGET_EXHAUSTED = (
+    "Retrieval budget exhausted; retrieve_docs is no longer available. "
+    'Respond ONLY with the {"action": "final", ...} JSON object now, '
+    "building the plan from the context you already have."
+)
+
+
 def _make_agent_node(llm: LLMClient, llm_model: Optional[str]):
     def agent_node(state: AgentState) -> AgentState:
+        exhausted = state.get("tool_calls", 0) >= MAX_TOOL_CALLS
         messages = [{"role": "system", "content": _SYSTEM}] + state["messages"]
+        if exhausted:
+            messages = messages + [{"role": "user", "content": _BUDGET_EXHAUSTED}]
         kwargs: Dict[str, Any] = {}
         if llm_model:
             kwargs["model"] = llm_model
@@ -90,10 +100,7 @@ def _make_agent_node(llm: LLMClient, llm_model: Optional[str]):
             "messages": state["messages"]
             + [{"role": "assistant", "content": result.get("text") or ""}],
         }
-        if (
-            decision.get("action") == "retrieve_docs"
-            and state.get("tool_calls", 0) < MAX_TOOL_CALLS
-        ):
+        if decision.get("action") == "retrieve_docs" and not exhausted:
             update["pending_query"] = str(
                 decision.get("query") or state["question"]
             )
@@ -169,6 +176,14 @@ def run_langgraph_architect(
     )
 
     plan_data = final.get("plan") or {}
+    if not str(plan_data.get("summary") or "").strip():
+        # A retrieve request converted at the cap, or a final with no content.
+        # Raising here lets run_architect_agent fall back to the builtin
+        # planner instead of streaming an empty plan to the client.
+        raise RuntimeError(
+            f"langgraph agent produced an empty plan after "
+            f"{int(final.get('tool_calls', 0))} tool calls"
+        )
     try:
         plan = ArchitectPlan(**plan_data)
     except Exception:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,28 @@ os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
 TRAIN_TIMEOUT_SECONDS = 180
 
 
+@pytest.fixture(autouse=True)
+def _isolate_llm_env(monkeypatch):
+    """Keep the developer's .env out of the test run.
+
+    app/main.py loads .env with override=True at import time (APP_ENV=local),
+    so importing the app anywhere in the session pulls real provider settings
+    and API keys into the process. Without this guard, tests written against
+    the stub provider silently make real, billed OpenAI calls and fail on
+    live output. Tests that need other values monkeypatch.setenv on top.
+    """
+    monkeypatch.setenv("LLM_PROVIDER", "stub")
+    for var in (
+        "AGENT_BACKEND",
+        "RAG_BACKEND",
+        "LLM_MODEL",
+        "OPENAI_API_KEY",
+        "LANGCHAIN_API_KEY",
+        "LANGCHAIN_TRACING_V2",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
 @pytest.fixture(scope="session")
 def trained_model(tmp_path_factory):
     """Run ml/train.py once per session and share the tracking store.

--- a/tests/test_langgraph_architect.py
+++ b/tests/test_langgraph_architect.py
@@ -7,8 +7,14 @@ from app.services.architect_agent import run_architect_agent
 
 
 def _scripted_llm(responses):
-    """Return a fake LLMClient.call that plays back scripted texts."""
-    it = iter(responses)
+    """Return a fake LLMClient.call that plays back scripted texts.
+
+    After the script is exhausted the last response repeats, so a builtin
+    fallback path that makes extra LLM calls does not hit StopIteration.
+    """
+    from itertools import chain, repeat
+
+    it = chain(iter(responses), repeat(responses[-1]))
 
     def _call(self, messages, model=None, **kwargs):
         return {
@@ -90,8 +96,45 @@ def test_langgraph_non_protocol_reply_becomes_summary(monkeypatch):
     assert plan.summary == "Just some prose answer."
 
 
-def test_langgraph_tool_call_cap(monkeypatch, tmp_path):
-    # The agent keeps asking for tools; the loop must stop at the cap.
+def test_langgraph_tool_call_cap_warns_then_finalizes(monkeypatch, tmp_path):
+    # The agent asks for tools until the cap; once told the budget is gone
+    # it must produce a real final plan, not an empty one.
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.txt").write_text("alpha beta gamma")
+    monkeypatch.setenv("DOCS_PATH", str(docs))
+    monkeypatch.setenv("AGENT_BACKEND", "langgraph")
+
+    seen_prompts = []
+    retrieve = json.dumps({"action": "retrieve_docs", "query": "alpha"})
+    final = json.dumps({"action": "final", "summary": "Plan built from gathered context."})
+    it = iter([retrieve, retrieve, retrieve, final])
+
+    def _call(self, messages, model=None, **kwargs):
+        seen_prompts.append(messages)
+        return {
+            "text": next(it),
+            "provider": "scripted",
+            "model": "unit-test",
+            "tokens_prompt": 10,
+            "tokens_completion": 5,
+            "cost_usd": 0.001,
+        }
+
+    monkeypatch.setattr(llm_mod.LLMClient, "call", _call)
+
+    plan, audit = run_architect_agent("Loop forever?")
+    assert audit["agent_backend"] == "langgraph"
+    assert audit["agent_tool_calls"] == 3  # MAX_TOOL_CALLS
+    assert plan.summary == "Plan built from gathered context."
+    # the 4th LLM turn (post-cap) must carry the budget-exhausted instruction
+    last_turn = seen_prompts[-1]
+    assert any("budget exhausted" in m["content"].lower() for m in last_turn)
+
+
+def test_langgraph_empty_plan_falls_back_to_builtin(monkeypatch, tmp_path):
+    # A model that ignores the budget warning and keeps requesting tools
+    # must not surface an empty plan: the builtin planner takes over.
     docs = tmp_path / "docs"
     docs.mkdir()
     (docs / "a.txt").write_text("alpha beta gamma")
@@ -102,8 +145,21 @@ def test_langgraph_tool_call_cap(monkeypatch, tmp_path):
     monkeypatch.setattr(llm_mod.LLMClient, "call", _scripted_llm(endless))
 
     plan, audit = run_architect_agent("Loop forever?")
-    assert audit["agent_backend"] == "langgraph"
-    assert audit["agent_tool_calls"] == 3  # MAX_TOOL_CALLS
+    # what matters: the empty langgraph plan never reaches the client
+    assert audit["agent_backend"] == "builtin"
+
+
+def test_langgraph_empty_final_summary_falls_back_to_builtin(monkeypatch):
+    # An immediate final with no summary is an empty plan too.
+    monkeypatch.setenv("AGENT_BACKEND", "langgraph")
+    monkeypatch.setattr(
+        llm_mod.LLMClient,
+        "call",
+        _scripted_llm([json.dumps({"action": "final", "summary": ""})]),
+    )
+
+    plan, audit = run_architect_agent("Empty final")
+    assert audit["agent_backend"] == "builtin"
 
 
 def test_default_backend_is_builtin(monkeypatch):


### PR DESCRIPTION
## What

Two bugs found today by the new LangSmith eval baseline (`baseline-langgraph-1024-d56ebd31`, 26-prompt golden dataset):

### 1. LangGraph agent returned empty plans on 8/18 grounded prompts

When the model asked for `retrieve_docs` after the 3-call budget was spent, `agent_node` converted that retrieve request into a "final" plan built from a decision dict that has no summary/steps -> empty plan streamed to the client, citations attached, no fallback (the builtin fallback only fires on exceptions).

Fix, two layers:
- At the cap, the agent node appends a budget-exhausted instruction so the model finalizes with the context it has
- If the plan still has no summary, `run_langgraph_architect` raises and the existing builtin-planner fallback engages

### 2. Tests silently made real, billed OpenAI calls

`app/main.py` loads `.env` with `override=True` at import time. Any test importing the app pulled `LLM_PROVIDER=openai` + real keys into the process. Result: 3 chronically failing local tests (passing in CI, which has no .env), a 185s suite, and real API spend on every local run.

Fix: autouse conftest fixture pins `LLM_PROVIDER=stub` and clears provider/tracing env. Suite: 136 passed, 55s, no live calls.

## Tests

- `test_langgraph_tool_call_cap_warns_then_finalizes`: model retrieves to the cap, gets the budget message, finalizes with a real plan
- `test_langgraph_empty_plan_falls_back_to_builtin`: model ignores the warning -> builtin backend serves the request
- `test_langgraph_empty_final_summary_falls_back_to_builtin`: immediate empty final -> builtin
- Full suite green locally including the 3 previously failing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)