### PR TITLE
feat(eval): Epic 3, rubric (code evaluators + judges + calibration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* LangSmith code evaluators (`scripts/langsmith_evaluators.py`): deterministic structural checks for experiment runs, ported from `run_live_eval.py` and extended with dataset-expectation checks (grounded/citations match, keywords, stream well-formedness, token-cap truncation, latency/TTFT). Category-aware: structure checks skip the negative/adversarial prompt set. Offline tests in `tests/test_langsmith_evaluators.py`.
+
 * LangSmith golden dataset tooling (`scripts/build_langsmith_dataset.py`): idempotent sync of `eval/architect_prompts_v2.jsonl` (26 prompts: grounded-core, new-features, negative/adversarial) into the `ai-architect-golden` dataset, keyed by example id with create/update/delete and `--dry-run`. Prompt set reviewed in `docs/eval_prompt_set_v2.md`; plan and backlog in `docs/langsmith_test_plan.md` / `docs/langsmith_eval_backlog.md`.
 
 * CI coverage gate: tests run with `pytest-cov` and fail under 75% line coverage (current baseline: 79%); coverage config in `pyproject.toml`, gate badge in the README.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* Judge calibration round 1 (`docs/eval_calibration_2026-07-04.md`): all 26 baseline judgments audited against the codebase; judge prompts gained hard rules (empty answer scores 1 everywhere, truncated snippet fragments are not evidence), a correctness cap when the question goes unanswered, grounding-aware completeness, and question-type-aware actionability. Re-judging the same answers moved completeness 3.85→3.38 and actionability 2.73→3.62. Also surfaced: the RAG corpus retrieves `docs/llm_agent_streaming_prompts.md` (the old test-prompt list) as context for eval questions, and the CI coverage gate is undocumented under docs/.
+
 * LangSmith LLM-judge evaluators and experiment harness (`scripts/langsmith_judges.py`, `scripts/run_langsmith_eval.py`): four 1-5 judges (correctness, groundedness, completeness, actionability) via litellm, judge prompts versioned in code; harness streams `/architect/stream` per dataset example and runs code evaluators + judges through `langsmith.evaluate()` with experiment metadata (agent backend, max tokens). Offline tests in `tests/test_langsmith_harness.py`.
 
 * LangSmith code evaluators (`scripts/langsmith_evaluators.py`): deterministic structural checks for experiment runs, ported from `run_live_eval.py` and extended with dataset-expectation checks (grounded/citations match, keywords, stream well-formedness, token-cap truncation, latency/TTFT). Category-aware: structure checks skip the negative/adversarial prompt set. Offline tests in `tests/test_langsmith_evaluators.py`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* LangSmith LLM-judge evaluators and experiment harness (`scripts/langsmith_judges.py`, `scripts/run_langsmith_eval.py`): four 1-5 judges (correctness, groundedness, completeness, actionability) via litellm, judge prompts versioned in code; harness streams `/architect/stream` per dataset example and runs code evaluators + judges through `langsmith.evaluate()` with experiment metadata (agent backend, max tokens). Offline tests in `tests/test_langsmith_harness.py`.
+
 * LangSmith code evaluators (`scripts/langsmith_evaluators.py`): deterministic structural checks for experiment runs, ported from `run_live_eval.py` and extended with dataset-expectation checks (grounded/citations match, keywords, stream well-formedness, token-cap truncation, latency/TTFT). Category-aware: structure checks skip the negative/adversarial prompt set. Offline tests in `tests/test_langsmith_evaluators.py`.
 
 * LangSmith golden dataset tooling (`scripts/build_langsmith_dataset.py`): idempotent sync of `eval/architect_prompts_v2.jsonl` (26 prompts: grounded-core, new-features, negative/adversarial) into the `ai-architect-golden` dataset, keyed by example id with create/update/delete and `--dry-run`. Prompt set reviewed in `docs/eval_prompt_set_v2.md`; plan and backlog in `docs/langsmith_test_plan.md` / `docs/langsmith_eval_backlog.md`.

--- a/docs/eval_calibration_2026-07-04.md
+++ b/docs/eval_calibration_2026-07-04.md
@@ -1,0 +1,59 @@
+# Judge calibration note, 2026-07-04 (LS-7)
+
+Calibrator: Hue (claude-fable-5), delegated by Rodrigo. Method: read all 26
+runs of experiment `baseline-fixed-v3-3def7580` (answers + judge reasoning),
+verify disputed claims against the actual codebase (not opinion vs opinion),
+fix the judge prompts, re-judge the same 26 answers, compare.
+
+## Disagreements found (pre-calibration)
+
+| # | Case | Judge said | Verified fact | Verdict |
+|---|---|---|---|---|
+| 1 | A8 correctness 5, groundedness 4 | env vars correctly identified | `G_BACKEND` does not exist anywhere in `app/` (grep: 0 hits). It is the tail of `RAG_BACKEND` cut mid-chunk in a retrieved snippet. The answer presented it as a real flag and the judges accepted it. | Judge fooled by truncated-snippet artifact |
+| 2 | A7 completeness 4, A9 completeness 5, B5 completeness 5 | "addresses all parts" | Same answers scored 1-2 on groundedness by the same judge model: the content was fabricated (A7 invented fallback values) or generic boilerplate (A9 localStorage advice). Sounding thorough counted as complete. | Completeness ignored grounding |
+| 3 | B7/B8/B4/C8 actionability 2-3 | "lacks commands/snippets" | These are what-is/explain questions (e.g. "which backend runs today?"). Answer named the real ADR, flag, and default. Demanding shell recipes for conceptual questions is judge fussiness. | Actionability miscalibrated to question type |
+| 4 | A1 correctness 5 | consistent with context | The real switches are `LLM_ENABLE_ARCHITECT` / `AGENT_BACKEND` (.env.example:29). Neither was retrieved, the answer paraphrased the `grounded` /query param instead and never answered the actual question. Context-consistency masked an unanswered question. | Correctness = faithfulness only; question left unanswered |
+| 5 | B6 correctness 4 vs groundedness 2 | contradictory reasoning on identical evidence | One judge said "aligns well with context", the other "not supported by context", same answer, same snippets. | Judge-vs-judge inconsistency |
+| 6 | (earlier smoke run) empty answer scored 4 | graded the citations | Answer payload was null. | Judge graded context instead of answer |
+
+## Prompt fixes applied (scripts/langsmith_judges.py)
+
+1. Hard rule: null/empty answer payload scores 1 on every dimension.
+2. Hard rule: names that only exist as truncated snippet fragments are not
+   evidence (the G_BACKEND rule).
+3. Correctness: context-consistency is necessary but not sufficient; if the
+   user's question goes unanswered with concrete supported facts, cap at 3.
+4. Completeness: only supported claims (or honest "not in the docs") count
+   toward coverage; fabricated filler scores 1-2.
+5. Actionability: calibrated to question type. How-to needs concrete steps;
+   what-is needs precise references, not recipes. Honest refusal stays fully
+   actionable. "Hypothetical" labels on invented names don't raise scores.
+
+## Re-judge of the same 26 answers (no app re-run)
+
+- judge_completeness 3.85 -> 3.38 (fabricated filler no longer counts: A7 4->1, A9 5->2, B5 5->2)
+- judge_actionability 2.73 -> 3.62 (conceptual questions no longer punished: B7 2->4, B8 2->4, B4 3->5)
+- judge_correctness 3.77 -> 3.58, judge_groundedness 3.73 -> 3.62 (mildly stricter)
+- B8 completeness 3 -> 5: honest "docs don't say" now counts as the right answer, which it is (see app findings).
+
+Residual disagreements (accepted for round 1): A8 correctness landed 4 not <=3
+(the fragment looks exactly like a real declaration at a chunk boundary);
+A1 correctness stayed 5 (the unanswered-question cap did not trigger because
+the answer does name a flag that exists in context). ~2 material disagreements
+out of 104 judgments post-calibration, under the 10% acceptance bar.
+
+## App/dataset findings surfaced by calibration (not judge bugs)
+
+1. **Retrieval self-pollution:** `docs/llm_agent_streaming_prompts.md` (the
+   old v1 test-prompt list) sits in the RAG corpus. Eval questions retrieve
+   the question list itself as "context" (visible in A7, A8, A9, B5 citations).
+   Recommendation: exclude that file from ingestion.
+2. **B8 is unanswerable from the corpus:** the 75% coverage gate lives in
+   CHANGELOG/README badge, not under docs/. Either document CI/testing under
+   docs/ (repo principle says docs track code) or drop the `75` keyword
+   expectation. The honest "not documented" answer was correct behavior.
+3. **Portuguese degrades retrieval (C5):** same question as A1 retrieved
+   weaker context in PT and produced admitted-hypothetical flags. Real
+   multilingual gap, worth a backlog item if PT users matter.
+4. **grounded_used still means "retrieval ran"**, not "the answer needed it";
+   C1-C3 baits still come back grounded_used=true (previously ticketed).

--- a/docs/langsmith_eval_backlog.md
+++ b/docs/langsmith_eval_backlog.md
@@ -57,21 +57,21 @@ Status legend: `todo` / `in-progress` / `review` / `done`
 ## Epic 3: Rubric (evaluators)
 
 ### LS-5: Code evaluators
-- **Status:** todo
+- **Status:** done (commit on epic-3 branch)
 - **Effort:** half day
 - **What:** Port heuristics from `scripts/run_live_eval.py` into LangSmith evaluator functions: has_summary (>= 40 chars), steps_count (>= 2), step_quality (>= 20 chars each), citations_present_when_grounded (reads example metadata), audit_event_emitted, stream_well_formed (meta, summary, steps, citations, audit all arrived), truncated (output cut by max_tokens: finish_reason or malformed-JSON tail; needed so LS-8 axis 2 shows truncation as a named cause, not mystery low completeness), latency + TTFT from trace timings.
 - **Acceptance:** Each evaluator returns a named score; a test run over 3 examples shows scores in the experiment view.
 - **Depends on:** LS-4b
 
 ### LS-6: LLM-as-judge evaluators
-- **Status:** todo
+- **Status:** done (verified via baseline-fixed-v3-3def7580)
 - **Effort:** 1 day
 - **What:** Four judges scoring 1-5 with reasoning: correctness (vs repo docs / retrieved chunks), groundedness (claims supported by citations, cited files exist), completeness (all parts of the question answered), actionability (steps followable without guessing). Start from LangSmith off-the-shelf prompts.
 - **Acceptance:** Judges run via `evaluate()` on the full dataset without errors; scores + reasoning visible per example.
 - **Depends on:** LS-4b, LS-5 (target function reuse)
 
 ### LS-7: Judge calibration pass
-- **Status:** todo
+- **Status:** done (see docs/eval_calibration_2026-07-04.md; delegated to Hue, verified against code)
 - **Effort:** half day
 - **What:** Read every judgment from one full run (~21 x 4). Where you disagree, adjust the judge prompt and re-run. Record disagreement rate before/after.
 - **Acceptance:** Documented calibration note; disagreement on a spot-check < ~10%.

--- a/docs/langsmith_eval_backlog.md
+++ b/docs/langsmith_eval_backlog.md
@@ -59,7 +59,7 @@ Status legend: `todo` / `in-progress` / `review` / `done`
 ### LS-5: Code evaluators
 - **Status:** todo
 - **Effort:** half day
-- **What:** Port heuristics from `scripts/run_live_eval.py` into LangSmith evaluator functions: has_summary (>= 40 chars), steps_count (>= 2), step_quality (>= 20 chars each), citations_present_when_grounded (reads example metadata), audit_event_emitted, stream_well_formed (meta, summary, steps, citations, audit all arrived), latency + TTFT from trace timings.
+- **What:** Port heuristics from `scripts/run_live_eval.py` into LangSmith evaluator functions: has_summary (>= 40 chars), steps_count (>= 2), step_quality (>= 20 chars each), citations_present_when_grounded (reads example metadata), audit_event_emitted, stream_well_formed (meta, summary, steps, citations, audit all arrived), truncated (output cut by max_tokens: finish_reason or malformed-JSON tail; needed so LS-8 axis 2 shows truncation as a named cause, not mystery low completeness), latency + TTFT from trace timings.
 - **Acceptance:** Each evaluator returns a named score; a test run over 3 examples shows scores in the experiment view.
 - **Depends on:** LS-4b
 
@@ -82,8 +82,8 @@ Status legend: `todo` / `in-progress` / `review` / `done`
 ### LS-8: evaluate() harness + first experiment
 - **Status:** todo
 - **Effort:** half day
-- **What:** `scripts/run_langsmith_eval.py` with a target function that streams `/architect/stream` (SSE) and assembles the final payload. Run the golden dataset through two configs (e.g. gpt-4o-mini vs a larger model) as two experiments.
-- **Acceptance:** Two experiments comparable side by side in LangSmith; a one-paragraph writeup of which won and why.
+- **What:** `scripts/run_langsmith_eval.py` with a target function that streams `/architect/stream` (SSE) and assembles the final payload. First experiment is a 2x2 grid over two live config questions instead of deciding them upfront (from .env review 2026-07-04): `AGENT_BACKEND` builtin vs langgraph, and `LLM_MAX_TOKENS` 1024 vs 2048. Four experiments x 26 prompts. Verdict metrics: backend axis = correctness/groundedness + latency + cost; token axis = completeness + the LS-5 `truncated` evaluator. Experiments tagged with their config.
+- **Acceptance:** Four experiments comparable side by side in LangSmith; a short writeup answering both config questions with scores, after which .env gets set to the winners.
 - **Depends on:** LS-5, LS-6
 
 ### LS-9: RAG flag experiments

--- a/scripts/langsmith_evaluators.py
+++ b/scripts/langsmith_evaluators.py
@@ -1,0 +1,215 @@
+"""Code evaluators for the Architect LangSmith experiments (backlog LS-5).
+
+Deterministic structural checks, ported from scripts/run_live_eval.py and
+extended with dataset-metadata-aware checks. LLM-as-judge evaluators (LS-6)
+live separately; these run first and are free.
+
+Contract: the experiment target function (scripts/run_langsmith_eval.py)
+assembles one output dict per example:
+
+    {
+        "meta": {...},            # SSE meta event (model, provider, grounded_used)
+        "summary": str | None,    # SSE summary event
+        "steps": [str] | None,    # SSE steps event
+        "citations": [...],       # SSE citations event
+        "audit": {...},           # SSE audit event (tokens, cost, agent_backend)
+        "events_seen": [str],     # every SSE event name received, in order
+        "config": {               # harness-recorded run config
+            "max_tokens": int | None,
+        },
+        "timing": {
+            "latency_s": float | None,
+            "ttft_s": float | None,
+        },
+    }
+
+Example metadata comes from eval/architect_prompts_v2.jsonl via the dataset
+(category, expect_grounded, expect_citations, keywords, expected_behavior).
+
+Each evaluator returns {"key", "score", "comment"} with score 1/0 (pass/fail),
+a float for informational metrics, or None when the check does not apply to
+the example's category (LangSmith renders None as "skipped").
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+SUMMARY_MIN_CHARS = 40
+STEPS_MIN_COUNT = 2
+STEP_MIN_CHARS = 20
+
+# Structure checks (summary/steps shape) only apply to categories whose
+# answers are expected to be full plans; the C-set is judged on behavior.
+STRUCTURED_CATEGORIES = ("grounded-core", "new-features")
+
+
+def _text_blob(outputs: Dict[str, Any]) -> str:
+    parts: List[str] = []
+    if outputs.get("summary"):
+        parts.append(str(outputs["summary"]))
+    for step in outputs.get("steps") or []:
+        parts.append(str(step))
+    return " ".join(parts).lower()
+
+
+def _is_structured(metadata: Dict[str, Any]) -> bool:
+    return metadata.get("category") in STRUCTURED_CATEGORIES
+
+
+def eval_has_summary(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    if not _is_structured(metadata):
+        return {"key": "has_summary", "score": None, "comment": "n/a for this category"}
+    length = len((outputs.get("summary") or "").strip())
+    return {
+        "key": "has_summary",
+        "score": int(length >= SUMMARY_MIN_CHARS),
+        "comment": f"summary length {length} (min {SUMMARY_MIN_CHARS})",
+    }
+
+
+def eval_steps_count(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    if not _is_structured(metadata):
+        return {"key": "steps_count", "score": None, "comment": "n/a for this category"}
+    steps = outputs.get("steps") or []
+    return {
+        "key": "steps_count",
+        "score": int(len(steps) >= STEPS_MIN_COUNT),
+        "comment": f"{len(steps)} steps (min {STEPS_MIN_COUNT})",
+    }
+
+
+def eval_step_quality(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    if not _is_structured(metadata):
+        return {"key": "step_quality", "score": None, "comment": "n/a for this category"}
+    steps = outputs.get("steps") or []
+    if not steps:
+        return {"key": "step_quality", "score": 0, "comment": "no steps"}
+    short = [s for s in steps if len(str(s).strip()) < STEP_MIN_CHARS]
+    return {
+        "key": "step_quality",
+        "score": int(not short),
+        "comment": f"{len(short)}/{len(steps)} steps under {STEP_MIN_CHARS} chars",
+    }
+
+
+def eval_grounded_matches_expectation(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    expected = metadata.get("expect_grounded")
+    if not isinstance(expected, bool):
+        return {"key": "grounded_matches_expectation", "score": None, "comment": "no expectation set"}
+    actual = (outputs.get("meta") or {}).get("grounded_used")
+    return {
+        "key": "grounded_matches_expectation",
+        "score": int(bool(actual) == expected),
+        "comment": f"grounded_used={actual}, expected {expected}",
+    }
+
+
+def eval_citations_expectation(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    expected = metadata.get("expect_citations")
+    if not isinstance(expected, bool):
+        return {"key": "citations_expectation", "score": None, "comment": "no expectation set"}
+    count = len(outputs.get("citations") or [])
+    ok = count > 0 if expected else count == 0
+    return {
+        "key": "citations_expectation",
+        "score": int(ok),
+        "comment": f"{count} citations, expected {'some' if expected else 'none'}",
+    }
+
+
+def eval_keywords_present(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    keywords = metadata.get("keywords") or []
+    if not keywords:
+        return {"key": "keywords_present", "score": None, "comment": "no keywords set"}
+    blob = _text_blob(outputs)
+    missing = [k for k in keywords if str(k).lower() not in blob]
+    return {
+        "key": "keywords_present",
+        "score": int(not missing),
+        "comment": f"missing: {missing}" if missing else "all keywords present",
+    }
+
+
+def eval_audit_event_emitted(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    audit = outputs.get("audit") or {}
+    return {
+        "key": "audit_event_emitted",
+        "score": int(bool(audit)),
+        "comment": f"audit keys: {len(audit)}",
+    }
+
+
+def eval_stream_well_formed(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    seen = outputs.get("events_seen") or []
+    required = {"meta", "audit"}
+    if _is_structured(metadata):
+        required |= {"summary", "steps"}
+    missing = sorted(required - set(seen))
+    return {
+        "key": "stream_well_formed",
+        "score": int(not missing),
+        "comment": f"missing events: {missing}" if missing else f"events: {seen}",
+    }
+
+
+def eval_not_truncated(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Flag outputs that hit the completion-token cap (LS-8 max-tokens axis).
+
+    No finish_reason survives the SSE stream, so hitting the cap is inferred
+    from llm_tokens_completion >= configured max_tokens.
+    """
+    max_tokens = (outputs.get("config") or {}).get("max_tokens")
+    completion = (outputs.get("audit") or {}).get("llm_tokens_completion")
+    if not max_tokens or completion is None:
+        return {"key": "not_truncated", "score": None, "comment": "token data unavailable"}
+    truncated = int(completion) >= int(max_tokens)
+    return {
+        "key": "not_truncated",
+        "score": int(not truncated),
+        "comment": f"completion tokens {completion} / cap {max_tokens}",
+    }
+
+
+def eval_latency(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    latency = (outputs.get("timing") or {}).get("latency_s")
+    return {
+        "key": "latency_s",
+        "score": round(float(latency), 3) if latency is not None else None,
+        "comment": "wall-clock stream duration",
+    }
+
+
+def eval_ttft(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    ttft = (outputs.get("timing") or {}).get("ttft_s")
+    return {
+        "key": "ttft_s",
+        "score": round(float(ttft), 3) if ttft is not None else None,
+        "comment": "time to first SSE event",
+    }
+
+
+ALL_EVALUATORS = [
+    eval_has_summary,
+    eval_steps_count,
+    eval_step_quality,
+    eval_grounded_matches_expectation,
+    eval_citations_expectation,
+    eval_keywords_present,
+    eval_audit_event_emitted,
+    eval_stream_well_formed,
+    eval_not_truncated,
+    eval_latency,
+    eval_ttft,
+]
+
+
+def run_code_evaluators(run, example) -> List[Dict[str, Any]]:
+    """LangSmith adapter: summary_evaluator-style entry point.
+
+    `run.outputs` is the target function's payload; `example.metadata` carries
+    the dataset expectations. Returns a list of feedback dicts for use with
+    langsmith.evaluate(..., evaluators=[run_code_evaluators]).
+    """
+    outputs: Dict[str, Any] = getattr(run, "outputs", None) or {}
+    metadata: Dict[str, Any] = getattr(example, "metadata", None) or {}
+    return [fn(outputs, metadata) for fn in ALL_EVALUATORS]

--- a/scripts/langsmith_judges.py
+++ b/scripts/langsmith_judges.py
@@ -21,8 +21,16 @@ _SYSTEM = (
     "You are a strict evaluation judge for an AI assistant that answers "
     "questions about the ai-architect codebase. Score the given dimension "
     "from 1 (very poor) to 5 (excellent). Be skeptical: unsupported or "
-    "invented claims must lose points. Respond ONLY with JSON: "
-    '{"score": <1-5>, "reasoning": "<2-3 sentences>"}'
+    "invented claims must lose points.\n"
+    "Hard rules that override everything else:\n"
+    "1. If the answer payload has a null/empty summary and no steps, the "
+    "score is 1 regardless of dimension or how good the retrieved context "
+    "looks. You are judging the answer, not the context.\n"
+    "2. Retrieved snippets are cut mid-sentence. A name (env var, file, "
+    "endpoint) that only appears as a truncated fragment is NOT evidence "
+    "it exists; treat names built from fragment edges (e.g. 'G_BACKEND' "
+    "from a cut 'RAG_BACKEND') as invented.\n"
+    'Respond ONLY with JSON: {"score": <1-5>, "reasoning": "<2-3 sentences>"}'
 )
 
 _DIMENSIONS: Dict[str, str] = {
@@ -30,28 +38,40 @@ _DIMENSIONS: Dict[str, str] = {
         "CORRECTNESS: Are the factual claims in the answer consistent with "
         "the retrieved context (citations/snippets)? Claims that contradict "
         "the context, or specifics (env vars, file paths, endpoints) that "
-        "appear in neither the context nor the question, score low. If the "
-        "expected behavior says the feature does not exist, a correct answer "
-        "says so plainly."
+        "appear in neither the context nor the question, score low. "
+        "Consistency with the context is necessary but not sufficient: if "
+        "the answer paraphrases the context without actually resolving the "
+        "user's question with a concrete, supported fact (e.g. names no real "
+        "flag when asked which flag to set), cap the score at 3 and say the "
+        "question went unanswered. If the expected behavior says the feature "
+        "does not exist, a correct answer says so plainly."
     ),
     "judge_groundedness": (
         "GROUNDEDNESS: Is every concrete claim supported by the retrieved "
         "context? An answer that invents configuration, files, or endpoints "
-        "not present in the context scores 1-2, even if plausible. An answer "
+        "not present in the context scores 1-2, even if plausible; labeling "
+        "invented names as 'hypothetical' does not raise the score. An answer "
         "that stays within the context, or explicitly says the information "
         "is not available, scores high."
     ),
     "judge_completeness": (
-        "COMPLETENESS: Does the answer address every part of the question? "
-        "Partial answers that silently drop sub-questions score low. If the "
-        "answer appears cut off mid-thought, score 1-2 and say so."
+        "COMPLETENESS: Does the answer address every part of the question "
+        "with SUPPORTED content? Only claims backed by the retrieved context "
+        "(or honest 'not in the docs' statements) count toward coverage; "
+        "fabricated or generic boilerplate does not, no matter how thorough "
+        "it sounds. If most of the coverage is unsupported filler, score 1-2. "
+        "Partial answers that silently drop sub-questions score low."
     ),
     "judge_actionability": (
-        "ACTIONABILITY: Could an engineer follow the suggested steps without "
-        "guessing? Steps must be concrete (which file, which flag, which "
-        "command). Vague advice ('configure appropriately') scores low. For "
-        "questions where refusing or asking for clarification is the right "
-        "move, a clear refusal/clarification is fully actionable."
+        "ACTIONABILITY: Could an engineer act on this answer without "
+        "guessing? Calibrate to the question type. For how-to questions, "
+        "steps must be concrete (which file, which flag, which command). For "
+        "explain/what-is questions, actionability means precise references "
+        "(real flag names, file paths, endpoints), not shell commands; do "
+        "not penalize the absence of a recipe nobody asked for. Vague advice "
+        "('configure appropriately') scores low. For questions where "
+        "refusing or asking for clarification is the right move, a clear "
+        "refusal/clarification is fully actionable."
     ),
 }
 

--- a/scripts/langsmith_judges.py
+++ b/scripts/langsmith_judges.py
@@ -1,0 +1,116 @@
+"""LLM-as-judge evaluators for the Architect LangSmith experiments (LS-6).
+
+Four judges, each scoring 1-5 with reasoning, via litellm (same dependency the
+app uses). Judge prompts are versioned here in code so calibration (LS-7)
+shows up as reviewable diffs.
+
+Judges read the target payload (see scripts/langsmith_evaluators.py for the
+contract) and the dataset example metadata. The C-set's `expected_behavior`
+text is passed to the judge verbatim, so hallucination-bait prompts are judged
+against "should say it doesn't exist", not against generic helpfulness.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+JUDGE_MODEL = os.getenv("EVAL_JUDGE_MODEL", "gpt-4.1-mini")
+
+_SYSTEM = (
+    "You are a strict evaluation judge for an AI assistant that answers "
+    "questions about the ai-architect codebase. Score the given dimension "
+    "from 1 (very poor) to 5 (excellent). Be skeptical: unsupported or "
+    "invented claims must lose points. Respond ONLY with JSON: "
+    '{"score": <1-5>, "reasoning": "<2-3 sentences>"}'
+)
+
+_DIMENSIONS: Dict[str, str] = {
+    "judge_correctness": (
+        "CORRECTNESS: Are the factual claims in the answer consistent with "
+        "the retrieved context (citations/snippets)? Claims that contradict "
+        "the context, or specifics (env vars, file paths, endpoints) that "
+        "appear in neither the context nor the question, score low. If the "
+        "expected behavior says the feature does not exist, a correct answer "
+        "says so plainly."
+    ),
+    "judge_groundedness": (
+        "GROUNDEDNESS: Is every concrete claim supported by the retrieved "
+        "context? An answer that invents configuration, files, or endpoints "
+        "not present in the context scores 1-2, even if plausible. An answer "
+        "that stays within the context, or explicitly says the information "
+        "is not available, scores high."
+    ),
+    "judge_completeness": (
+        "COMPLETENESS: Does the answer address every part of the question? "
+        "Partial answers that silently drop sub-questions score low. If the "
+        "answer appears cut off mid-thought, score 1-2 and say so."
+    ),
+    "judge_actionability": (
+        "ACTIONABILITY: Could an engineer follow the suggested steps without "
+        "guessing? Steps must be concrete (which file, which flag, which "
+        "command). Vague advice ('configure appropriately') scores low. For "
+        "questions where refusing or asking for clarification is the right "
+        "move, a clear refusal/clarification is fully actionable."
+    ),
+}
+
+
+def _render_payload(outputs: Dict[str, Any]) -> str:
+    citations = outputs.get("citations") or []
+    ctx_lines = []
+    for c in citations[:10]:
+        if isinstance(c, dict):
+            ctx_lines.append(f"- {c.get('source')}: {str(c.get('snippet'))[:300]}")
+    return json.dumps(
+        {
+            "summary": outputs.get("summary"),
+            "steps": outputs.get("steps"),
+            "grounded_used": (outputs.get("meta") or {}).get("grounded_used"),
+        },
+        ensure_ascii=False,
+    ) + ("\n\nRetrieved context:\n" + "\n".join(ctx_lines) if ctx_lines else "\n\nRetrieved context: (none)")
+
+
+def _judge_once(dimension_key: str, question: str, outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    import litellm
+
+    expected = metadata.get("expected_behavior")
+    user = (
+        f"Dimension to score:\n{_DIMENSIONS[dimension_key]}\n\n"
+        f"Question asked:\n{question}\n\n"
+        + (f"Expected behavior for this test case:\n{expected}\n\n" if expected else "")
+        + f"Assistant answer payload:\n{_render_payload(outputs)}"
+    )
+    resp = litellm.completion(
+        model=JUDGE_MODEL,
+        messages=[{"role": "system", "content": _SYSTEM}, {"role": "user", "content": user}],
+        temperature=0.0,
+        max_tokens=300,
+        response_format={"type": "json_object"},
+    )
+    parsed = json.loads(resp.choices[0].message.content)
+    score = max(1, min(5, int(parsed.get("score", 0))))
+    return {"key": dimension_key, "score": score, "comment": str(parsed.get("reasoning", ""))[:500]}
+
+
+def _make_judge(dimension_key: str):
+    def _evaluator(run, example) -> Dict[str, Any]:
+        outputs: Dict[str, Any] = getattr(run, "outputs", None) or {}
+        metadata: Dict[str, Any] = getattr(example, "metadata", None) or {}
+        question: str = ((getattr(example, "inputs", None) or {}).get("question")) or ""
+        try:
+            return _judge_once(dimension_key, question, outputs, metadata)
+        except Exception as exc:  # judge failure must not sink the experiment
+            return {"key": dimension_key, "score": None, "comment": f"judge error: {exc}"}
+
+    _evaluator.__name__ = dimension_key
+    return _evaluator
+
+
+judge_correctness = _make_judge("judge_correctness")
+judge_groundedness = _make_judge("judge_groundedness")
+judge_completeness = _make_judge("judge_completeness")
+judge_actionability = _make_judge("judge_actionability")
+
+ALL_JUDGES = [judge_correctness, judge_groundedness, judge_completeness, judge_actionability]

--- a/scripts/run_langsmith_eval.py
+++ b/scripts/run_langsmith_eval.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""LangSmith experiment harness for the Architect agent (LS-6/LS-8).
+
+Streams each dataset example through GET /architect/stream (SSE), assembles
+the payload contract from scripts/langsmith_evaluators.py, and runs the code
+evaluators plus the four LLM judges via langsmith.evaluate().
+
+Usage:
+    # smoke run: 3 examples, code evaluators only
+    python scripts/run_langsmith_eval.py --limit 3 --no-judges
+
+    # full run with judges
+    python scripts/run_langsmith_eval.py --experiment-prefix baseline-langgraph-1024
+
+Env: LANGCHAIN_API_KEY (LangSmith), OPENAI_API_KEY (judges).
+The current app config is recorded on the experiment via --agent-backend /
+--max-tokens metadata flags (the harness cannot see the server's env).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from langsmith_evaluators import run_code_evaluators  # noqa: E402
+
+
+def stream_architect(question: str, url: str, timeout: float, max_tokens: Optional[int]) -> Dict[str, Any]:
+    """Consume the SSE stream and assemble the evaluator payload contract."""
+    events_seen: List[str] = []
+    collected: Dict[str, Any] = {"meta": {}, "summary": None, "steps": None, "citations": [], "audit": {}}
+    start = time.monotonic()
+    ttft: Optional[float] = None
+
+    with httpx.Client(timeout=timeout) as client:
+        with client.stream(
+            "GET", url, params={"question": question}, headers={"Accept": "text/event-stream"}
+        ) as resp:
+            resp.raise_for_status()
+            current_event: Optional[str] = None
+            data_buf: List[str] = []
+            for line in resp.iter_lines():
+                line = (line or "").strip()
+                if line == "":
+                    if current_event and data_buf:
+                        if ttft is None:
+                            ttft = time.monotonic() - start
+                        events_seen.append(current_event)
+                        try:
+                            payload = json.loads("\n".join(data_buf))
+                        except Exception:
+                            payload = None
+                        if current_event == "meta" and isinstance(payload, dict):
+                            collected["meta"] = payload
+                        elif current_event == "summary" and isinstance(payload, str):
+                            collected["summary"] = payload
+                        elif current_event == "steps" and isinstance(payload, list):
+                            collected["steps"] = [str(x) for x in payload]
+                        elif current_event == "citations" and isinstance(payload, list):
+                            collected["citations"] = payload
+                        elif current_event == "audit" and isinstance(payload, dict):
+                            collected["audit"] = payload
+                    current_event = None
+                    data_buf = []
+                elif line.startswith("event:"):
+                    current_event = line.split(":", 1)[1].strip()
+                    data_buf = []
+                elif line.startswith("data:"):
+                    data_buf.append(line.split(":", 1)[1].strip())
+
+    collected["events_seen"] = events_seen
+    collected["config"] = {"max_tokens": max_tokens}
+    collected["timing"] = {"latency_s": round(time.monotonic() - start, 3), "ttft_s": round(ttft, 3) if ttft else None}
+    return collected
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", default="ai-architect-golden")
+    parser.add_argument("--url", default="http://localhost:8000/architect/stream")
+    parser.add_argument("--limit", type=int, default=0, help="run only the first N examples (0 = all)")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--no-judges", action="store_true", help="code evaluators only (free, fast)")
+    parser.add_argument("--experiment-prefix", default="architect-eval")
+    parser.add_argument("--agent-backend", default=os.getenv("AGENT_BACKEND", "unknown"),
+                        help="recorded as experiment metadata; must match the running server")
+    parser.add_argument("--max-tokens", type=int, default=int(os.getenv("LLM_MAX_TOKENS", "0")) or None,
+                        help="server's LLM_MAX_TOKENS; feeds the not_truncated evaluator")
+    args = parser.parse_args()
+
+    if not os.getenv("LANGCHAIN_API_KEY"):
+        print("LANGCHAIN_API_KEY is not set", file=sys.stderr)
+        return 1
+
+    from langsmith import Client
+    from langsmith.evaluation import evaluate
+
+    client = Client()
+
+    data = args.dataset
+    if args.limit:
+        examples = list(client.list_examples(dataset_name=args.dataset))
+        examples.sort(key=lambda e: (e.metadata or {}).get("id", ""))
+        data = examples[: args.limit]
+
+    def target(inputs: Dict[str, Any]) -> Dict[str, Any]:
+        return stream_architect(inputs["question"], args.url, args.timeout, args.max_tokens)
+
+    def code_evaluators(run, example) -> Dict[str, Any]:
+        return {"results": run_code_evaluators(run, example)}
+
+    evaluators = [code_evaluators]
+    if not args.no_judges:
+        from langsmith_judges import ALL_JUDGES
+
+        evaluators.extend(ALL_JUDGES)
+
+    result = evaluate(
+        target,
+        data=data,
+        evaluators=evaluators,
+        experiment_prefix=args.experiment_prefix,
+        metadata={
+            "agent_backend": args.agent_backend,
+            "max_tokens": args.max_tokens,
+            "judges": not args.no_judges,
+        },
+        max_concurrency=2,  # be gentle: each target call is a live LLM request
+    )
+    print(f"\nexperiment: {result.experiment_name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_langsmith_evaluators.py
+++ b/tests/test_langsmith_evaluators.py
@@ -1,0 +1,152 @@
+"""Offline tests for the LS-5 code evaluators (scripts/langsmith_evaluators.py)."""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from langsmith_evaluators import (  # noqa: E402
+    ALL_EVALUATORS,
+    eval_audit_event_emitted,
+    eval_citations_expectation,
+    eval_grounded_matches_expectation,
+    eval_has_summary,
+    eval_keywords_present,
+    eval_latency,
+    eval_not_truncated,
+    eval_step_quality,
+    eval_steps_count,
+    eval_stream_well_formed,
+    eval_ttft,
+    run_code_evaluators,
+)
+
+GROUNDED_META = {
+    "id": "A1",
+    "category": "grounded-core",
+    "expect_grounded": True,
+    "expect_citations": True,
+    "keywords": ["env", "flag"],
+}
+NEGATIVE_META = {
+    "id": "C1",
+    "category": "negative",
+    "expect_grounded": False,
+    "expect_citations": False,
+}
+
+GOOD_OUTPUTS = {
+    "meta": {"model": "gpt-4.1", "provider": "openai", "grounded_used": True},
+    "summary": "Enable Architect mode by setting the LLM_ENABLE_ARCHITECT env flag to true in .env.",
+    "steps": [
+        "Set LLM_ENABLE_ARCHITECT=true in your .env file",
+        "Restart the API so the new flag values are picked up",
+    ],
+    "citations": [{"source": "docs/config.md"}],
+    "audit": {"llm_tokens_completion": 512, "agent_backend": "builtin"},
+    "events_seen": ["meta", "summary", "steps", "citations", "audit"],
+    "config": {"max_tokens": 1024},
+    "timing": {"latency_s": 3.21, "ttft_s": 0.42},
+}
+
+
+def test_good_grounded_run_passes_everything():
+    results = {r["key"]: r for fn in ALL_EVALUATORS for r in [fn(GOOD_OUTPUTS, GROUNDED_META)]}
+    for key in (
+        "has_summary",
+        "steps_count",
+        "step_quality",
+        "grounded_matches_expectation",
+        "citations_expectation",
+        "keywords_present",
+        "audit_event_emitted",
+        "stream_well_formed",
+        "not_truncated",
+    ):
+        assert results[key]["score"] == 1, f"{key}: {results[key]}"
+    assert results["latency_s"]["score"] == 3.21
+    assert results["ttft_s"]["score"] == 0.42
+
+
+def test_structure_checks_skip_negative_category():
+    for fn in (eval_has_summary, eval_steps_count, eval_step_quality):
+        assert fn(GOOD_OUTPUTS, NEGATIVE_META)["score"] is None
+
+
+def test_short_summary_fails():
+    outputs = dict(GOOD_OUTPUTS, summary="Too short.")
+    assert eval_has_summary(outputs, GROUNDED_META)["score"] == 0
+
+
+def test_missing_and_short_steps_fail():
+    assert eval_steps_count(dict(GOOD_OUTPUTS, steps=["only one step here, quite long"]), GROUNDED_META)["score"] == 0
+    assert eval_step_quality(dict(GOOD_OUTPUTS, steps=["tiny", "also tiny"]), GROUNDED_META)["score"] == 0
+    assert eval_step_quality(dict(GOOD_OUTPUTS, steps=[]), GROUNDED_META)["score"] == 0
+
+
+def test_grounded_expectation_mismatch():
+    hallucinated = dict(GOOD_OUTPUTS, meta={"grounded_used": True})
+    assert eval_grounded_matches_expectation(hallucinated, NEGATIVE_META)["score"] == 0
+    assert eval_grounded_matches_expectation(GOOD_OUTPUTS, GROUNDED_META)["score"] == 1
+    # C4/C6 style: expect_citations null in jsonl -> no expectation -> skip
+    assert eval_grounded_matches_expectation(GOOD_OUTPUTS, {"category": "negative"})["score"] is None
+
+
+def test_citations_expectation_both_directions():
+    assert eval_citations_expectation(dict(GOOD_OUTPUTS, citations=[]), GROUNDED_META)["score"] == 0
+    bait_answer = dict(GOOD_OUTPUTS, citations=[])
+    assert eval_citations_expectation(bait_answer, NEGATIVE_META)["score"] == 1
+    invented = dict(GOOD_OUTPUTS, citations=[{"source": "docs/redis.md"}])
+    assert eval_citations_expectation(invented, NEGATIVE_META)["score"] == 0
+    assert eval_citations_expectation(GOOD_OUTPUTS, {"expect_citations": None})["score"] is None
+
+
+def test_keywords_case_insensitive_and_missing():
+    assert eval_keywords_present(GOOD_OUTPUTS, GROUNDED_META)["score"] == 1
+    meta = dict(GROUNDED_META, keywords=["prometheus"])
+    result = eval_keywords_present(GOOD_OUTPUTS, meta)
+    assert result["score"] == 0
+    assert "prometheus" in result["comment"]
+    assert eval_keywords_present(GOOD_OUTPUTS, NEGATIVE_META)["score"] is None
+
+
+def test_stream_well_formed_requirements_by_category():
+    no_steps = dict(GOOD_OUTPUTS, events_seen=["meta", "summary", "audit"])
+    assert eval_stream_well_formed(no_steps, GROUNDED_META)["score"] == 0
+    # negative category only requires meta + audit
+    assert eval_stream_well_formed(dict(GOOD_OUTPUTS, events_seen=["meta", "audit"]), NEGATIVE_META)["score"] == 1
+    assert eval_stream_well_formed(dict(GOOD_OUTPUTS, events_seen=["meta"]), NEGATIVE_META)["score"] == 0
+
+
+def test_audit_event_emitted():
+    assert eval_audit_event_emitted(GOOD_OUTPUTS, GROUNDED_META)["score"] == 1
+    assert eval_audit_event_emitted(dict(GOOD_OUTPUTS, audit={}), GROUNDED_META)["score"] == 0
+
+
+def test_not_truncated_detects_cap_hit():
+    at_cap = dict(GOOD_OUTPUTS, audit={"llm_tokens_completion": 1024})
+    assert eval_not_truncated(at_cap, GROUNDED_META)["score"] == 0
+    assert eval_not_truncated(GOOD_OUTPUTS, GROUNDED_META)["score"] == 1
+    no_config = dict(GOOD_OUTPUTS, config={})
+    assert eval_not_truncated(no_config, GROUNDED_META)["score"] is None
+    no_tokens = dict(GOOD_OUTPUTS, audit={})
+    assert eval_not_truncated(no_tokens, GROUNDED_META)["score"] is None
+
+
+def test_timing_metrics_handle_missing_data():
+    assert eval_latency(dict(GOOD_OUTPUTS, timing={}), GROUNDED_META)["score"] is None
+    assert eval_ttft(dict(GOOD_OUTPUTS, timing={}), GROUNDED_META)["score"] is None
+
+
+def test_langsmith_adapter_shapes():
+    run = SimpleNamespace(outputs=GOOD_OUTPUTS)
+    example = SimpleNamespace(metadata=GROUNDED_META)
+    feedback = run_code_evaluators(run, example)
+    assert len(feedback) == len(ALL_EVALUATORS)
+    keys = {f["key"] for f in feedback}
+    assert "grounded_matches_expectation" in keys
+    for f in feedback:
+        assert set(f) == {"key", "score", "comment"}
+    # tolerate empty run/example
+    empty = run_code_evaluators(SimpleNamespace(outputs=None), SimpleNamespace(metadata=None))
+    assert len(empty) == len(ALL_EVALUATORS)

--- a/tests/test_langsmith_harness.py
+++ b/tests/test_langsmith_harness.py
@@ -1,0 +1,130 @@
+"""Offline tests for the LS-6 harness and judges (no network, no LLM)."""
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from run_langsmith_eval import stream_architect  # noqa: E402
+import langsmith_judges as judges  # noqa: E402
+
+SSE_BODY = (
+    b"event: meta\ndata: {\"model\": \"stub\", \"grounded_used\": true}\n\n"
+    b"event: summary\ndata: \"A plan summary that is long enough to pass checks.\"\n\n"
+    b"event: steps\ndata: [\"Set the flag in .env and restart\", \"Verify via /architect\"]\n\n"
+    b"event: citations\ndata: [{\"source\": \"docs/config.md\", \"snippet\": \"flags...\"}]\n\n"
+    b"event: audit\ndata: {\"llm_tokens_completion\": 100}\n\n"
+)
+
+
+def _mock_stream(body: bytes = SSE_BODY):
+    def handler(request):
+        return httpx.Response(200, content=body, headers={"content-type": "text/event-stream"})
+
+    return httpx.MockTransport(handler)
+
+
+def test_stream_architect_assembles_payload_contract():
+    transport = _mock_stream()
+    real_client = httpx.Client
+
+    def client_factory(**kwargs):
+        return real_client(transport=transport, **kwargs)
+
+    with patch("run_langsmith_eval.httpx.Client", side_effect=client_factory):
+        out = stream_architect("q", "http://test/architect/stream", timeout=5, max_tokens=1024)
+
+    assert out["events_seen"] == ["meta", "summary", "steps", "citations", "audit"]
+    assert out["meta"]["grounded_used"] is True
+    assert out["summary"].startswith("A plan summary")
+    assert out["steps"] == ["Set the flag in .env and restart", "Verify via /architect"]
+    assert out["citations"][0]["source"] == "docs/config.md"
+    assert out["audit"]["llm_tokens_completion"] == 100
+    assert out["config"] == {"max_tokens": 1024}
+    assert out["timing"]["latency_s"] is not None
+    assert out["timing"]["ttft_s"] is not None
+
+
+def test_stream_architect_tolerates_malformed_event():
+    body = b"event: meta\ndata: not-json\n\nevent: audit\ndata: {}\n\n"
+    transport = _mock_stream(body)
+    real_client = httpx.Client
+
+    def client_factory(**kwargs):
+        return real_client(transport=transport, **kwargs)
+
+    with patch("run_langsmith_eval.httpx.Client", side_effect=client_factory):
+        out = stream_architect("q", "http://test/x", timeout=5, max_tokens=None)
+
+    assert out["events_seen"] == ["meta", "audit"]
+    assert out["meta"] == {}  # malformed payload dropped, event still counted
+
+
+def test_render_payload_includes_answer_and_context():
+    text = judges._render_payload(
+        {
+            "summary": "s",
+            "steps": ["a"],
+            "meta": {"grounded_used": False},
+            "citations": [{"source": "docs/x.md", "snippet": "y" * 400}],
+        }
+    )
+    assert '"summary": "s"' in text
+    assert "docs/x.md" in text
+    assert len(text) < 1000  # snippet capped
+
+
+def test_render_payload_no_citations():
+    assert "Retrieved context: (none)" in judges._render_payload({"summary": None})
+
+
+def test_judge_parses_llm_json(monkeypatch):
+    def fake_completion(**kwargs):
+        msg = SimpleNamespace(content=json.dumps({"score": 7, "reasoning": "clamped"}))
+        return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+    import litellm
+
+    monkeypatch.setattr(litellm, "completion", fake_completion)
+    result = judges._judge_once("judge_correctness", "q", {"summary": "s"}, {})
+    assert result == {"key": "judge_correctness", "score": 5, "comment": "clamped"}  # clamped to 1-5
+
+
+def test_judge_expected_behavior_reaches_prompt(monkeypatch):
+    captured = {}
+
+    def fake_completion(**kwargs):
+        captured["user"] = kwargs["messages"][1]["content"]
+        msg = SimpleNamespace(content=json.dumps({"score": 2, "reasoning": "r"}))
+        return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+    import litellm
+
+    monkeypatch.setattr(litellm, "completion", fake_completion)
+    judges._judge_once(
+        "judge_groundedness", "redis?", {"summary": "s"}, {"expected_behavior": "Says no Redis cache exists"}
+    )
+    assert "Says no Redis cache exists" in captured["user"]
+
+
+def test_judge_evaluator_survives_llm_error(monkeypatch):
+    import litellm
+
+    def boom(**kwargs):
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(litellm, "completion", boom)
+    run = SimpleNamespace(outputs={"summary": "s"})
+    example = SimpleNamespace(inputs={"question": "q"}, metadata={})
+    result = judges.judge_correctness(run, example)
+    assert result["score"] is None
+    assert "provider down" in result["comment"]
+
+
+def test_all_judges_have_distinct_keys():
+    keys = {j.__name__ for j in judges.ALL_JUDGES}
+    assert keys == {"judge_correctness", "judge_groundedness", "judge_completeness", "judge_actionability"}


### PR DESCRIPTION
## What (LS-5, LS-6, LS-7)

- **LS-5** `scripts/langsmith_evaluators.py`: 11 deterministic evaluators over the assembled SSE payload (structure, dataset-expectation matches, stream well-formedness, token-cap truncation, latency/TTFT). Category-aware: structure checks skip the adversarial C-set.
- **LS-6** `scripts/langsmith_judges.py` + `scripts/run_langsmith_eval.py`: four 1-5 judges (correctness, groundedness, completeness, actionability) via litellm (gpt-4.1-mini), and the `evaluate()` harness streaming `/architect/stream` per dataset example. Judge prompts live in code so calibration is reviewable diffs.
- **LS-7** calibration round 1: all 26 baseline judgments audited against the codebase, four systematic judge errors fixed, same answers re-judged. Full log: `docs/eval_calibration_2026-07-04.md`.
- 20 offline tests (`tests/test_langsmith_evaluators.py`, `tests/test_langsmith_harness.py`), evaluators/judges at 100% file coverage.
- Also carries the LS-8 2x2-grid backlog commit that missed the PR #20 merge window.

## Live verification

- Experiments on dataset `ai-architect-golden`: `baseline-langgraph-1024-d56ebd31` (pre-bugfix), `baseline-fixed-v3-3def7580` (post-fix, all 15 metrics attached).
- The rubric caught the langgraph empty-plan bug fixed in #21; before/after: structure metrics 0.56 -> 1.00, judges +0.7 to +1.2.
- Calibration re-judge deltas: completeness 3.85 -> 3.38 (fabricated filler no longer counts), actionability 2.73 -> 3.62 (what-is questions no longer punished for lacking shell recipes). Worst pre-calibration error: judges validated `G_BACKEND`, an env var that does not exist (truncation artifact of RAG_BACKEND in a retrieved chunk).

## Findings for follow-up (not in this PR)

1. RAG corpus self-pollution: `docs/llm_agent_streaming_prompts.md` gets retrieved as context for eval questions. Should be excluded from ingestion.
2. CI coverage gate is undocumented under docs/ (B8 unanswerable from corpus; docs-track-code principle).
3. Portuguese query (C5) degrades retrieval vs the same question in English.
4. `grounded_used` means "retrieval ran", not "answer is grounded" (previously noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)