### PR TITLE
fix(rag): exclude eval/test-prompt docs from the grounding corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 ### Fixed
 
+* RAG corpus exclusions (`RAG_EXCLUDE_FILES`): eval/test-prompt docs (the v1 streaming prompt list and the LangSmith eval docs) are excluded from grounding by default across the keyword scan, its fallbacks, vector ingestion, and vector query (query-time filter catches stale chunks). Found during judge calibration: eval questions retrieved the question list itself as context. Tests in `tests/test_rag_exclusions.py`.
+
 * LangGraph architect no longer returns empty plans when it hits the tool-call cap: the agent is told the retrieval budget is exhausted and must finalize; if the plan still has no summary the builtin planner takes over (found by LangSmith eval baseline: 8/18 grounded prompts affected).
 * Tests no longer inherit the developer's `.env` (loaded with `override=True` by `app/main.py` at import): an autouse fixture pins the stub provider and clears provider/tracing keys, ending silent live OpenAI calls from the suite.
 

--- a/app/services/doc_retriever.py
+++ b/app/services/doc_retriever.py
@@ -11,6 +11,30 @@ is missing or empty).
 import os
 from typing import Any, Dict, List, Tuple
 
+# Files under DOCS_PATH that must never be used as grounding context.
+# Default excludes the eval/test-prompt docs: their entries match eval and
+# user questions nearly verbatim, so retrieval returns the question list
+# itself as "context" (found during judge calibration, 2026-07-04; the v2
+# prompt doc reproduced the problem the moment the v1 file was excluded).
+_DEFAULT_EXCLUDES = ",".join(
+    [
+        "llm_agent_streaming_prompts.md",
+        "eval_prompt_set_v2.md",
+        "langsmith_test_plan.md",
+        "langsmith_eval_backlog.md",
+        "eval_calibration_2026-07-04.md",
+    ]
+)
+
+
+def excluded_files() -> set:
+    raw = os.getenv("RAG_EXCLUDE_FILES", _DEFAULT_EXCLUDES)
+    return {f.strip().lower() for f in raw.split(",") if f.strip()}
+
+
+def is_excluded(filename: str) -> bool:
+    return os.path.basename(filename).lower() in excluded_files()
+
 
 def is_enabled() -> bool:
     # keyword scan is currently the sole retrieval backend
@@ -69,7 +93,7 @@ def _scan_docs_for_terms(docs_path: str, terms: List[str]) -> List[Dict[str, Any
         return citations
     for root, _, files in os.walk(docs_path):
         for fn in files:
-            if fn.lower().endswith((".txt", ".md")):
+            if fn.lower().endswith((".txt", ".md")) and not is_excluded(fn):
                 path = os.path.join(root, fn)
                 try:
                     with open(path, "r", encoding="utf-8", errors="ignore") as f:
@@ -219,6 +243,8 @@ def answer_with_citations(question: str, k: int = 3) -> Dict[str, Any]:
         fname_match_path = None
         for root, _, files in os.walk(docs_path):
             for fn in files:
+                if is_excluded(fn):
+                    continue
                 fn_low = fn.lower()
                 if any(t in fn_low for t in norm_terms):
                     p = os.path.join(root, fn)
@@ -231,8 +257,9 @@ def answer_with_citations(question: str, k: int = 3) -> Dict[str, Any]:
         # 2) If no filename match, fall back to first text-like file (or any file)
         if not target_path:
             for root, _, files in os.walk(docs_path):
-                text_files = [f for f in files if f.lower().endswith((".txt", ".md"))]
-                search_list = text_files if text_files else files
+                candidates = [f for f in files if not is_excluded(f)]
+                text_files = [f for f in candidates if f.lower().endswith((".txt", ".md"))]
+                search_list = text_files if text_files else candidates
                 for fn in search_list:
                     p = os.path.join(root, fn)
                     if os.path.isfile(p):

--- a/app/services/vector_retriever.py
+++ b/app/services/vector_retriever.py
@@ -90,11 +90,15 @@ def query(question: str, k: int = 3) -> List[Dict[str, Any]]:
 
     Raises on any backend failure; the caller decides whether to fall back.
     """
+    from app.services.doc_retriever import is_excluded
+
     col = get_collection()
     emb = get_embedder().embed([question])[0]
+    # Over-fetch so query-time exclusion (stale chunks from files that were
+    # ingested before landing on RAG_EXCLUDE_FILES) still yields k results.
     res = col.query(
         query_embeddings=[emb],
-        n_results=max(1, k),
+        n_results=max(1, k) * 2,
         include=["documents", "metadatas", "distances"],
     )
     citations: List[Dict[str, Any]] = []
@@ -103,7 +107,11 @@ def query(question: str, k: int = 3) -> List[Dict[str, Any]]:
     metas = (res.get("metadatas") or [[]])[0]
     dists = (res.get("distances") or [[]])[0]
     for i in range(len(ids[0])):
+        if len(citations) >= max(1, k):
+            break
         meta = metas[i] if i < len(metas) else {}
+        if is_excluded(str((meta or {}).get("source", ""))):
+            continue
         snippet = (docs[i] if i < len(docs) else "")[:200].replace("\n", " ")
         citations.append(
             {

--- a/scripts/ingest_docs.py
+++ b/scripts/ingest_docs.py
@@ -45,8 +45,13 @@ def chunk_text(text: str, size: int = 1000, overlap: int = 200):
 
 
 def iter_documents(docs_path: str):
+    from app.services.doc_retriever import is_excluded
+
     for root, _, files in os.walk(docs_path):
         for fn in sorted(files):
+            if is_excluded(fn):
+                print(f"exclude {os.path.join(root, fn)} (RAG_EXCLUDE_FILES)")
+                continue
             path = os.path.join(root, fn)
             low = fn.lower()
             try:

--- a/tests/test_rag_exclusions.py
+++ b/tests/test_rag_exclusions.py
@@ -1,0 +1,84 @@
+"""RAG corpus exclusions (RAG_EXCLUDE_FILES): the test-prompt list must
+never be retrieved as grounding context."""
+import sys
+from pathlib import Path
+
+from app.services.doc_retriever import answer_with_citations, excluded_files, is_excluded
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+
+def _corpus(tmp_path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "audit.md").write_text("Audit rows are written by write_audit with retention settings.")
+    (docs / "llm_agent_streaming_prompts.md").write_text(
+        "Where are audit rows written and which fields are tracked? "
+        "How do I configure retention and metrics?"
+    )
+    return docs
+
+
+def test_default_excludes_prompt_list():
+    assert is_excluded("llm_agent_streaming_prompts.md")
+    assert is_excluded("/some/dir/LLM_Agent_Streaming_Prompts.md")  # case + path insensitive
+    assert not is_excluded("audit.md")
+
+
+def test_env_override(monkeypatch):
+    monkeypatch.setenv("RAG_EXCLUDE_FILES", "a.md, B.md")
+    assert excluded_files() == {"a.md", "b.md"}
+    assert is_excluded("b.md")
+    assert not is_excluded("llm_agent_streaming_prompts.md")
+
+
+def test_keyword_scan_never_cites_excluded_file(monkeypatch, tmp_path):
+    docs = _corpus(tmp_path)
+    monkeypatch.setenv("DOCS_PATH", str(docs))
+    # the excluded file matches the question verbatim; it must still not appear
+    res = answer_with_citations("Where are audit rows written and how do I configure retention?")
+    sources = [c["source"] for c in res["citations"]]
+    assert sources, "expected the real doc to match"
+    assert all("llm_agent_streaming_prompts" not in s for s in sources)
+
+
+def test_fallback_paths_skip_excluded_file(monkeypatch, tmp_path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    # ONLY the excluded file exists: fallback must not resurrect it
+    (docs / "llm_agent_streaming_prompts.md").write_text("prompt list content")
+    monkeypatch.setenv("DOCS_PATH", str(docs))
+    res = answer_with_citations("zzz nothing matches this")
+    assert res["citations"] == []
+
+
+def test_ingest_iter_documents_skips_excluded(monkeypatch, tmp_path, capsys):
+    docs = _corpus(tmp_path)
+    from ingest_docs import iter_documents
+
+    paths = [p for p, _ in iter_documents(str(docs))]
+    assert any(p.endswith("audit.md") for p in paths)
+    assert not any("llm_agent_streaming_prompts" in p for p in paths)
+    assert "exclude" in capsys.readouterr().out
+
+
+def test_vector_query_filters_stale_excluded_chunks(monkeypatch):
+    from app.services import vector_retriever
+
+    class FakeCol:
+        def query(self, **kwargs):
+            return {
+                "ids": [["a", "b"]],
+                "documents": [["prompt list text", "real audit text"]],
+                "metadatas": [[{"source": "llm_agent_streaming_prompts.md"}, {"source": "audit.md"}]],
+                "distances": [[0.1, 0.2]],
+            }
+
+    class FakeEmb:
+        def embed(self, texts):
+            return [[0.0]]
+
+    monkeypatch.setattr(vector_retriever, "get_collection", lambda create=False: FakeCol())
+    monkeypatch.setattr(vector_retriever, "get_embedder", lambda: FakeEmb())
+    citations = vector_retriever.query("audit?", k=1)
+    assert [c["source"] for c in citations] == ["audit.md"]


### PR DESCRIPTION
## What

Calibration finding #1 from `docs/eval_calibration_2026-07-04.md`: the RAG corpus contains the eval prompt docs, and since eval questions match them nearly verbatim, retrieval returns the question list itself as "context" (visible in A7/A8/A9/B5 citations in experiment `baseline-fixed-v3-3def7580`).

- New `RAG_EXCLUDE_FILES` env (comma-separated basenames). Default excludes `llm_agent_streaming_prompts.md` plus the four LangSmith eval docs (the v2 prompt doc reproduced the pollution the moment the v1 file was excluded, caught during live verification).
- Honored in: keyword scan, filename-match fallback, first-file fallback, vector ingestion (`scripts/ingest_docs.py`), and vector query (query-time filter with 2x over-fetch so stale chunks from stores built before this change are also filtered).
- 6 tests in `tests/test_rag_exclusions.py`.

## Verification

- Rebuilt the local Chroma store: 5 files excluded at ingest, 243 chunks remain.
- Live `/architect/stream` check on the A9 question: citations went from including `llm_agent_streaming_prompts.md` / `eval_prompt_set_v2.md` to `agents.md`, `api.md`, `memory.md`, `architect_deterministic_mode.md`.
- Full suite: 162 passed.

## Note

`tests/test_vector_rag.py::test_query_endpoint_reports_vector_backend` fails when run in isolation on main too (import-order dependence: `app.main`'s `load_dotenv(override=True)` clobbers the test's monkeypatched env on first import). Passes in the full suite. Pre-existing, not addressed here.

This unblocks the LS-8 2x2 experiment: cells should be compared on a corpus that doesn't contain the answers-shaped-as-questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)