### PR TITLE
feat(eval): Epic 4, experiment grid (LS-8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* LS-8 experiment grid (`scripts/run_experiment_grid.py`): cycles .env per cell (AGENT_BACKEND x LLM_MAX_TOKENS), trips the uvicorn reloader, health-gates, runs the golden dataset, verifies each experiment's audit backend, restores .env. Verdict in `docs/eval_results/2026-07-04-grid-backend-tokens.md`: langgraph beats builtin on groundedness/correctness/completeness AND latency; 1024 tokens never truncates. Evaluators now also emit `cost_usd` and `completion_tokens` feedback so experiments aggregate spend.
+
 * Judge calibration round 1 (`docs/eval_calibration_2026-07-04.md`): all 26 baseline judgments audited against the codebase; judge prompts gained hard rules (empty answer scores 1 everywhere, truncated snippet fragments are not evidence), a correctness cap when the question goes unanswered, grounding-aware completeness, and question-type-aware actionability. Re-judging the same answers moved completeness 3.85→3.38 and actionability 2.73→3.62. Also surfaced: the RAG corpus retrieves `docs/llm_agent_streaming_prompts.md` (the old test-prompt list) as context for eval questions, and the CI coverage gate is undocumented under docs/.
 
 * LangSmith LLM-judge evaluators and experiment harness (`scripts/langsmith_judges.py`, `scripts/run_langsmith_eval.py`): four 1-5 judges (correctness, groundedness, completeness, actionability) via litellm, judge prompts versioned in code; harness streams `/architect/stream` per dataset example and runs code evaluators + judges through `langsmith.evaluate()` with experiment metadata (agent backend, max tokens). Offline tests in `tests/test_langsmith_harness.py`.

--- a/docs/eval_results/2026-07-04-grid-backend-tokens.md
+++ b/docs/eval_results/2026-07-04-grid-backend-tokens.md
@@ -1,0 +1,64 @@
+# LS-8 experiment: AGENT_BACKEND x LLM_MAX_TOKENS (2026-07-04)
+
+2x2 grid, 26-prompt `ai-architect-golden` dataset per cell, calibrated judges
+(see `eval_calibration_2026-07-04.md`), clean corpus (post PR #23), model
+gpt-4.1, temperature 0. Experiments (LangSmith):
+
+| cell | experiment |
+|---|---|
+| builtin-1024 | grid-builtin-1024-b1c83aac |
+| builtin-2048 | grid-builtin-2048-d7964d89 |
+| langgraph-1024 | grid-langgraph-1024-bf4e26be |
+| langgraph-2048 | grid-langgraph-2048-236ad1f9 |
+
+Every cell's `audit.agent_backend` was verified against the intended config.
+
+## Results (per-cell averages)
+
+| metric | builtin-1024 | builtin-2048 | langgraph-1024 | langgraph-2048 |
+|---|---|---|---|---|
+| judge_correctness | 3.54 | 3.23 | **3.81** | 3.73 |
+| judge_groundedness | 3.19 | 2.92 | **3.96** | 3.81 |
+| judge_completeness | 3.08 | 3.00 | **3.62** | 3.35 |
+| judge_actionability | 3.69 | 3.77 | 3.38 | 3.69 |
+| has_summary | 0.94 | 0.94 | 1.00 | 1.00 |
+| not_truncated | 1.00 | 1.00 | 1.00 | 1.00 |
+| completion_tokens (avg) | 319 | 333 | 281 | 277 |
+| latency_s (avg) | 22.5 | 20.6 | **13.5** | 15.7 |
+| cost_usd (avg/request) | ~equal across cells (fractions of a cent) | | | |
+
+## Verdict
+
+**Backend axis: langgraph wins, decisively.** Better on groundedness
+(+0.77 to +0.89, the metric that matters most for a RAG assistant), better on
+correctness and completeness, AND ~7-9s faster per request despite making up
+to 4 LLM turns; the builtin path's fixed pipeline (memory + multi-variant
+retrieval + single big prompt) costs more wall-clock than the tool loop.
+Actionability is the one metric where builtin edges ahead at 1024; it
+equalizes at 2048 and doesn't outweigh the groundedness gap. Post-#21 (cap
+warning + fallback), langgraph also no longer produces empty plans (1.00
+has_summary).
+
+**Token axis: dead, 1024 wins for free.** No run in any cell hit the cap
+(max avg completion 333 tokens vs 1024 budget; not_truncated 1.00
+everywhere), and 2048 bought no completeness (it dipped slightly, noise).
+The 2026-07-04 worry that 1024 might truncate C8-style answers is measured
+and dismissed.
+
+**.env setting: `AGENT_BACKEND=langgraph`, `LLM_MAX_TOKENS=1024`**, which is
+what it already was; the config survives, now with evidence instead of vibes.
+
+## Notes / carry-forward
+
+- `grounded_matches_expectation` flat at 0.846 across all cells: the C-set
+  hallucination baits fail it identically regardless of backend/tokens.
+  Confirms it's a retrieval-semantics issue (`grounded_used` = "retrieval
+  ran"), not a generation issue. Still the standing design ticket.
+- LS-9 design correction: `RAG_MULTI_QUERY_ENABLED` / `RAG_HYDE_ENABLED` only
+  affect the keyword-scan path; with `RAG_BACKEND=vector` (current prod) they
+  are no-ops. The useful round-two axes are `RAG_BACKEND` vector vs
+  keyword_scan, and the model shootout (gpt-4.1 vs gpt-4.1-mini with judges
+  upgraded via `EVAL_JUDGE_MODEL`).
+- Grid mechanics: `scripts/run_experiment_grid.py` cycles .env per cell
+  (touch app/main.py to trip the uvicorn reloader), waits for /healthz, and
+  verifies each experiment's audit backend. .env is restored afterwards.

--- a/docs/langsmith_eval_backlog.md
+++ b/docs/langsmith_eval_backlog.md
@@ -80,7 +80,7 @@ Status legend: `todo` / `in-progress` / `review` / `done`
 ## Epic 4: Experiments
 
 ### LS-8: evaluate() harness + first experiment
-- **Status:** todo
+- **Status:** done (see docs/eval_results/2026-07-04-grid-backend-tokens.md; winners = langgraph + 1024, already in .env)
 - **Effort:** half day
 - **What:** `scripts/run_langsmith_eval.py` with a target function that streams `/architect/stream` (SSE) and assembles the final payload. First experiment is a 2x2 grid over two live config questions instead of deciding them upfront (from .env review 2026-07-04): `AGENT_BACKEND` builtin vs langgraph, and `LLM_MAX_TOKENS` 1024 vs 2048. Four experiments x 26 prompts. Verdict metrics: backend axis = correctness/groundedness + latency + cost; token axis = completeness + the LS-5 `truncated` evaluator. Experiments tagged with their config.
 - **Acceptance:** Four experiments comparable side by side in LangSmith; a short writeup answering both config questions with scores, after which .env gets set to the winners.
@@ -89,7 +89,7 @@ Status legend: `todo` / `in-progress` / `review` / `done`
 ### LS-9: RAG flag experiments
 - **Status:** todo
 - **Effort:** half day
-- **What:** Same harness, toggling multi-query and hyDE. Tag experiments with the flag combo.
+- **What:** DESIGN CORRECTED 2026-07-04: multi-query/hyDE flags are no-ops under RAG_BACKEND=vector (they only affect the keyword scan). Round two axes instead: RAG_BACKEND vector vs keyword_scan, and the model shootout gpt-4.1 vs gpt-4.1-mini (judges upgraded via EVAL_JUDGE_MODEL for that run).
 - **Acceptance:** 3-4 experiments tagged by flag combo; findings noted in `docs/live_eval.md` or a new results doc.
 - **Depends on:** LS-8
 

--- a/scripts/langsmith_evaluators.py
+++ b/scripts/langsmith_evaluators.py
@@ -170,6 +170,25 @@ def eval_not_truncated(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dic
     }
 
 
+def eval_cost(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Surface audit.llm_cost_usd as feedback so experiments aggregate cost."""
+    cost = (outputs.get("audit") or {}).get("llm_cost_usd")
+    return {
+        "key": "cost_usd",
+        "score": round(float(cost), 5) if cost is not None else None,
+        "comment": "from audit.llm_cost_usd (LiteLLM pricing map)",
+    }
+
+
+def eval_completion_tokens(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    tokens = (outputs.get("audit") or {}).get("llm_tokens_completion")
+    return {
+        "key": "completion_tokens",
+        "score": int(tokens) if tokens is not None else None,
+        "comment": "from audit.llm_tokens_completion",
+    }
+
+
 def eval_latency(outputs: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
     latency = (outputs.get("timing") or {}).get("latency_s")
     return {
@@ -198,6 +217,8 @@ ALL_EVALUATORS = [
     eval_audit_event_emitted,
     eval_stream_well_formed,
     eval_not_truncated,
+    eval_cost,
+    eval_completion_tokens,
     eval_latency,
     eval_ttft,
 ]

--- a/scripts/run_experiment_grid.py
+++ b/scripts/run_experiment_grid.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Run the LS-8 2x2 experiment grid: AGENT_BACKEND x LLM_MAX_TOKENS.
+
+For each cell: rewrite .env, touch app/main.py (trips the uvicorn reloader,
+whose re-import re-runs load_dotenv(override=True)), wait for /health, then
+run scripts/run_langsmith_eval.py against the golden dataset. The original
+.env values are restored at the end regardless of outcome.
+
+After each cell, one run's audit.agent_backend is checked against the cell's
+intended backend, so a reload that silently didn't take fails loudly instead
+of producing a mislabeled experiment.
+
+Usage:
+    python scripts/run_experiment_grid.py            # all 4 cells
+    python scripts/run_experiment_grid.py --cells langgraph-2048
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+REPO = Path(__file__).resolve().parent.parent
+ENV_FILE = REPO / ".env"
+TOUCH_TARGET = REPO / "app" / "main.py"
+HEALTH_URL = "http://localhost:8000/healthz"
+
+CELLS = [
+    {"backend": "builtin", "max_tokens": 1024},
+    {"backend": "builtin", "max_tokens": 2048},
+    {"backend": "langgraph", "max_tokens": 1024},
+    {"backend": "langgraph", "max_tokens": 2048},
+]
+
+
+def cell_name(cell: dict) -> str:
+    return f"{cell['backend']}-{cell['max_tokens']}"
+
+
+def set_env_values(backend: str, max_tokens: int) -> None:
+    text = ENV_FILE.read_text()
+    text, n1 = re.subn(r"(?m)^AGENT_BACKEND=.*$", f"AGENT_BACKEND={backend}", text)
+    text, n2 = re.subn(r"(?m)^LLM_MAX_TOKENS=.*$", f"LLM_MAX_TOKENS={max_tokens}", text)
+    if n1 != 1 or n2 != 1:
+        raise RuntimeError(f"expected exactly one AGENT_BACKEND/LLM_MAX_TOKENS line, got {n1}/{n2}")
+    ENV_FILE.write_text(text)
+
+
+def trigger_reload_and_wait(timeout_s: float = 90.0) -> None:
+    TOUCH_TARGET.touch()
+    time.sleep(3)  # give the reloader a moment to tear down the old worker
+    deadline = time.monotonic() + timeout_s
+    ok_streak = 0
+    while time.monotonic() < deadline:
+        try:
+            if httpx.get(HEALTH_URL, timeout=3).status_code == 200:
+                ok_streak += 1
+                if ok_streak >= 2:  # stable across two checks
+                    return
+            else:
+                ok_streak = 0
+        except Exception:
+            ok_streak = 0
+        time.sleep(1.5)
+    raise RuntimeError("server did not become healthy after reload")
+
+
+def run_cell(cell: dict, python: str) -> str:
+    prefix = f"grid-{cell_name(cell)}"
+    cmd = [
+        python,
+        str(REPO / "scripts" / "run_langsmith_eval.py"),
+        "--experiment-prefix", prefix,
+        "--agent-backend", cell["backend"],
+        "--max-tokens", str(cell["max_tokens"]),
+    ]
+    print(f"\n=== cell {cell_name(cell)} -> {prefix} ===", flush=True)
+    res = subprocess.run(cmd, cwd=REPO, text=True, capture_output=True)
+    print(res.stdout[-2000:], flush=True)
+    if res.returncode != 0:
+        print(res.stderr[-2000:], file=sys.stderr, flush=True)
+        raise RuntimeError(f"cell {cell_name(cell)} failed")
+    m = re.search(r"experiment: (\S+)", res.stdout)
+    return m.group(1) if m else prefix
+
+
+def verify_cell_backend(experiment: str, expected_backend: str) -> None:
+    from langsmith import Client
+    from langsmith.utils import LangSmithNotFoundError
+
+    client = Client()
+    # The experiment project can lag behind the evaluate() return
+    # (read-after-write); retry before treating it as missing.
+    runs = []
+    deadline = time.monotonic() + 120
+    while time.monotonic() < deadline:
+        try:
+            runs = list(client.list_runs(project_name=experiment, is_root=True, limit=3))
+            if runs:
+                break
+        except LangSmithNotFoundError:
+            pass
+        time.sleep(10)
+    for run in runs:
+        actual = ((run.outputs or {}).get("audit") or {}).get("agent_backend")
+        if actual and actual != expected_backend:
+            raise RuntimeError(
+                f"experiment {experiment}: audit.agent_backend={actual!r}, "
+                f"expected {expected_backend!r} — reload did not take"
+            )
+        if actual:
+            print(f"verified: {experiment} ran on agent_backend={actual}", flush=True)
+            return
+    print(f"warning: {experiment} had no audit backend to verify", flush=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cells", nargs="*", help="subset, e.g. langgraph-2048")
+    args = parser.parse_args()
+
+    cells = [c for c in CELLS if not args.cells or cell_name(c) in args.cells]
+    if not cells:
+        print("no matching cells", file=sys.stderr)
+        return 1
+
+    python = sys.executable
+    original = ENV_FILE.read_text()
+    results: dict = {}
+    try:
+        for cell in cells:
+            set_env_values(cell["backend"], cell["max_tokens"])
+            trigger_reload_and_wait()
+            experiment = run_cell(cell, python)
+            verify_cell_backend(experiment, cell["backend"])
+            results[cell_name(cell)] = experiment
+    finally:
+        ENV_FILE.write_text(original)
+        try:
+            trigger_reload_and_wait()
+            print("\n.env restored to original values, server reloaded", flush=True)
+        except Exception as exc:
+            print(f"\n.env restored, but reload check failed: {exc}", file=sys.stderr, flush=True)
+
+    print("\n=== grid complete ===")
+    for name, exp in results.items():
+        print(f"{name}: {exp}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_experiment_grid.py
+++ b/tests/test_experiment_grid.py
@@ -1,0 +1,97 @@
+"""Offline tests for the LS-8 grid runner (scripts/run_experiment_grid.py)."""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import run_experiment_grid as grid  # noqa: E402
+
+
+ENV_TEMPLATE = """\
+LLM_PROVIDER=openai
+AGENT_BACKEND=langgraph
+LLM_MAX_TOKENS=1024
+RAG_BACKEND=vector
+"""
+
+
+@pytest.fixture
+def env_file(tmp_path, monkeypatch):
+    path = tmp_path / ".env"
+    path.write_text(ENV_TEMPLATE)
+    monkeypatch.setattr(grid, "ENV_FILE", path)
+    return path
+
+
+def test_cell_name():
+    assert grid.cell_name({"backend": "builtin", "max_tokens": 2048}) == "builtin-2048"
+
+
+def test_grid_has_four_unique_cells():
+    names = [grid.cell_name(c) for c in grid.CELLS]
+    assert len(names) == 4
+    assert len(set(names)) == 4
+
+
+def test_set_env_values_rewrites_only_target_lines(env_file):
+    grid.set_env_values("builtin", 2048)
+    text = env_file.read_text()
+    assert "AGENT_BACKEND=builtin" in text
+    assert "LLM_MAX_TOKENS=2048" in text
+    # untouched neighbours survive
+    assert "LLM_PROVIDER=openai" in text
+    assert "RAG_BACKEND=vector" in text
+
+
+def test_set_env_values_requires_exactly_one_line(env_file):
+    env_file.write_text(ENV_TEMPLATE + "AGENT_BACKEND=builtin\n")
+    with pytest.raises(RuntimeError, match="exactly one"):
+        grid.set_env_values("langgraph", 1024)
+
+
+def test_set_env_values_missing_key(env_file):
+    env_file.write_text("LLM_PROVIDER=openai\n")
+    with pytest.raises(RuntimeError):
+        grid.set_env_values("builtin", 1024)
+
+
+def test_run_cell_parses_experiment_name(monkeypatch):
+    res = SimpleNamespace(returncode=0, stdout="...\nexperiment: grid-builtin-1024-abc123\n", stderr="")
+    monkeypatch.setattr(grid.subprocess, "run", lambda *a, **k: res)
+    name = grid.run_cell({"backend": "builtin", "max_tokens": 1024}, "python")
+    assert name == "grid-builtin-1024-abc123"
+
+
+def test_run_cell_falls_back_to_prefix(monkeypatch):
+    res = SimpleNamespace(returncode=0, stdout="no name here", stderr="")
+    monkeypatch.setattr(grid.subprocess, "run", lambda *a, **k: res)
+    assert grid.run_cell({"backend": "langgraph", "max_tokens": 2048}, "python") == "grid-langgraph-2048"
+
+
+def test_run_cell_raises_on_failure(monkeypatch):
+    res = SimpleNamespace(returncode=1, stdout="", stderr="boom")
+    monkeypatch.setattr(grid.subprocess, "run", lambda *a, **k: res)
+    with pytest.raises(RuntimeError, match="failed"):
+        grid.run_cell({"backend": "builtin", "max_tokens": 1024}, "python")
+
+
+def test_main_rejects_unknown_cell(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["run_experiment_grid.py", "--cells", "nope-42"])
+    assert grid.main() == 1
+    assert "no matching cells" in capsys.readouterr().err
+
+
+def test_main_restores_env_on_cell_failure(env_file, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["run_experiment_grid.py", "--cells", "builtin-2048"])
+    monkeypatch.setattr(grid, "trigger_reload_and_wait", lambda *a, **k: None)
+
+    def boom(cell, python):
+        raise RuntimeError("cell exploded")
+
+    monkeypatch.setattr(grid, "run_cell", boom)
+    with pytest.raises(RuntimeError, match="cell exploded"):
+        grid.main()
+    assert env_file.read_text() == ENV_TEMPLATE

--- a/tests/test_langsmith_evaluators.py
+++ b/tests/test_langsmith_evaluators.py
@@ -150,3 +150,12 @@ def test_langsmith_adapter_shapes():
     # tolerate empty run/example
     empty = run_code_evaluators(SimpleNamespace(outputs=None), SimpleNamespace(metadata=None))
     assert len(empty) == len(ALL_EVALUATORS)
+
+
+def test_cost_and_tokens_metrics():
+    from langsmith_evaluators import eval_completion_tokens, eval_cost
+
+    outputs = dict(GOOD_OUTPUTS, audit={"llm_cost_usd": 0.004834, "llm_tokens_completion": 118})
+    assert eval_cost(outputs, GROUNDED_META)["score"] == 0.00483
+    assert eval_completion_tokens(outputs, GROUNDED_META)["score"] == 118
+    assert eval_cost(dict(GOOD_OUTPUTS, audit={}), GROUNDED_META)["score"] is None


### PR DESCRIPTION
## What (LS-8)

- `scripts/run_experiment_grid.py`: runs the 2x2 grid (AGENT_BACKEND x LLM_MAX_TOKENS). Per cell: rewrite .env, touch app/main.py to trip the uvicorn reloader (whose re-import re-runs load_dotenv override), wait for /healthz, run the 26-prompt golden dataset via the LS-6 harness, then verify the experiment's `audit.agent_backend` matches the intended cell. .env restored afterwards.
- Evaluators now emit `cost_usd` and `completion_tokens` feedback (from the audit event) so experiments aggregate spend in LangSmith. Requested by Rodrigo; cell 1 was backfilled via the API.
- Verdict writeup: `docs/eval_results/2026-07-04-grid-backend-tokens.md`.

## Results (26 prompts/cell, calibrated judges, clean corpus)

| metric | builtin-1024 | builtin-2048 | langgraph-1024 | langgraph-2048 |
|---|---|---|---|---|
| groundedness | 3.19 | 2.92 | **3.96** | 3.81 |
| correctness | 3.54 | 3.23 | **3.81** | 3.73 |
| completeness | 3.08 | 3.00 | **3.62** | 3.35 |
| latency (s) | 22.5 | 20.6 | **13.5** | 15.7 |
| not_truncated | 1.00 | 1.00 | 1.00 | 1.00 |

**Backend: langgraph wins decisively** (better grounding AND faster, despite up to 4 LLM turns). **Token axis: dead**, nothing ever approaches the 1024 cap. Winners = `AGENT_BACKEND=langgraph`, `LLM_MAX_TOKENS=1024`, which is the existing .env config, now evidence-backed.

## LS-9 design correction

`RAG_MULTI_QUERY_ENABLED`/`RAG_HYDE_ENABLED` only affect the keyword-scan path and are no-ops under `RAG_BACKEND=vector` (current prod). Backlog updated: round two = RAG_BACKEND vector vs keyword_scan + the gpt-4.1 vs gpt-4.1-mini shootout (with judges upgraded via `EVAL_JUDGE_MODEL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)