### PR TITLE
docs: accuracy refresh — sync docs with shipped reality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,13 +6,26 @@ REQUEST_ID_HEADER=X-Request-ID
 # RBAC / Security
 # METRICS_TOKEN=
 
+# Backends (the headline switches; defaults shown)
+AGENT_BACKEND=builtin           # builtin|langgraph (langgraph won the measured comparison, see docs/eval_results/)
+RAG_BACKEND=keyword_scan        # keyword_scan|vector (vector needs scripts/ingest_docs.py first)
+PII_BACKEND=regex               # regex|presidio (presidio: pip install .[presidio])
+
 # RAG & Router
-LC_RAG_ENABLED=true
 ROUTER_ENABLED=true
-EMBEDDINGS_PROVIDER=local
+# ROUTER_BACKEND=               # router implementation override
+# ROUTER_RULES_JSON=            # inline rules JSON (or ROUTER_RULES_PATH=path to rules file)
+EMBEDDINGS_PROVIDER=local       # local|openai|hash|stub
+# LOCAL_EMBEDDING_MODEL=all-MiniLM-L6-v2
+# OPENAI_EMBEDDING_MODEL=text-embedding-ada-002
 VECTORSTORE_PATH=./.local/vectorstore
+# RAG_COLLECTION=               # Chroma collection name
+# NOTE: with DOCS_PATH unset, the keyword-scan query path defaults to ./examples
+# while scripts/ingest_docs.py defaults to ./docs — set it explicitly:
 DOCS_PATH=./docs
-# RAG multi-query
+# RAG_EXCLUDE_FILES=            # comma-separated basenames never used as grounding
+                                # (default already excludes the eval/prompt docs)
+# RAG multi-query (keyword-scan path only; no-ops under RAG_BACKEND=vector)
 RAG_MULTI_QUERY_ENABLED=true
 RAG_MULTI_QUERY_COUNT=3
 RAG_HYDE_ENABLED=true
@@ -20,15 +33,16 @@ RAG_HYDE_ENABLED=true
 # Architect
 PROJECT_GUIDE_ENABLED=true
 
-# LLM Provider (defaults keep offline stub)
-LLM_PROVIDER=openai      # stub|openai|openrouter|azure
+# LLM Provider (code default is the offline stub; this example opts into OpenAI —
+# set LLM_PROVIDER=stub for fully offline operation)
+LLM_PROVIDER=openai      # stub|openai|... (real providers route through LiteLLM)
 LLM_MODEL=gpt-4o-mini       # adjust per provider
 LLM_TEMPERATURE=0.0
 LLM_MAX_TOKENS=512
 LLM_ENABLE_QUERY=true
 LLM_ENABLE_ARCHITECT=true
-LLM_ENABLE_RESEARCH=true
 OPENAI_API_KEY=
+# Read by LiteLLM at call time, not by app code:
 OPENROUTER_API_KEY=
 AZURE_OPENAI_API_KEY=
 AZURE_OPENAI_ENDPOINT=
@@ -53,22 +67,40 @@ MEMORY_LONG_MAX_FACTS=0
 POLICY_NAV_ENABLED=true
 POLICY_NAV_MAX_SUBQS=3
 
+# PII detection
+# PII_TYPES=email,phone,ssn,credit_card,ipv4
+# PII_LOCALES=
+# PII_PRESIDIO_THRESHOLD=0.5    # presidio backend only
+# PII_SPACY_MODEL=en_core_web_sm
+
 # PII Remediation
 PII_REMEDIATION_ENABLED=true
-PII_REMEDIATION_INCLUDE_SNIPPETS=true
+
+# Risk scoring
+# RISK_ML_ENABLED=false
+# RISK_THRESHOLD=0.6
+
+# Research agent safety
+# AGENT_LIVE_MODE=false         # allow live HTTP fetch in /research
+# AGENT_URL_ALLOWLIST=          # comma-separated URL prefixes
+# DENYLIST=                     # risk_check denylist terms
 
 # DB
 DB_URL=sqlite:///./audit.db
 
 # ML / Training
 MLFLOW_TRACKING_URI=./.mlruns
-MLFLOW_EXPERIMENT_NAME=ai-monitor
+MLFLOW_EXPERIMENT_NAME=ai-architect
+# MLFLOW_MODEL_URI=             # explicit model for /predict (else latest run)
+# MLFLOW_MODEL_ARTIFACT_PATH=model
+# MLFLOW_FEATURE_ORDER_ARTIFACT=feature_order.json
+# MLFLOW_MODEL_CACHE_TTL=0
 
-# LangChain Tracing / Monitoring
+# LangSmith tracing / eval (tracing requires BOTH of the first two)
 LANGCHAIN_TRACING_V2=true
-LANGCHAIN_TRACING_SESSION_NAME=ai-architect
-LANGCHAIN_PROJECT=ai-architect
 LANGCHAIN_API_KEY=
+LANGCHAIN_PROJECT=ai-architect
+# EVAL_JUDGE_MODEL=gpt-4.1-mini # LLM judge for the eval pipeline
 
 # Dev / Overrides
 # If you need torch in dev, keep CPU index; remove if not needed

--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@
 
 - **Transparent** by design — audit logs, hashed request/response pairs.
 - **Observable** — Prometheus `/metrics` + Grafana dashboards.
-- **Cost-aware** — per-request token accounting and FinOps metrics (real per-model $ cost via LiteLLM is on the roadmap).
+- **Cost-aware** — per-request token accounting and FinOps metrics, with real per-model $ cost from LiteLLM's pricing map.
+- **Evaluated** — a LangSmith golden dataset, 11 code evaluators + 4 calibrated LLM judges, and config decisions made by experiment (see [Evaluation](#-evaluation)).
 - **Governed** — RBAC, retention sweeps, and prompt registries.
 
-> **Project status:** a reference implementation you can run locally. Out of the box the LLM runs in a deterministic offline **stub** unless a provider key is set; retrieval ships a **keyword/deterministic baseline** (vector retrieval is next on the roadmap); the architect runs a structured **deterministic planner** (a LangGraph tool-loop agent is on the roadmap). Shipped vs planned lives in [docs/MODERNIZATION_PLAN.md](docs/MODERNIZATION_PLAN.md).
+> **Project status:** a reference implementation you can run locally. Out of the box the LLM runs in a deterministic offline **stub** unless a provider key is set; retrieval defaults to a **keyword/deterministic baseline** with real **vector retrieval** (Chroma) behind `RAG_BACKEND=vector`; the architect defaults to a structured **deterministic planner** with a **LangGraph tool-loop agent** behind `AGENT_BACKEND=langgraph` (the measured winner on groundedness and latency — see [docs/eval_results/](docs/eval_results/2026-07-04-grid-backend-tokens.md)). Shipped vs planned lives in [docs/MODERNIZATION_PLAN.md](docs/MODERNIZATION_PLAN.md).
 
 ---
 
@@ -75,8 +76,8 @@ python3 -m venv .venv
 . .venv/bin/activate
 pip install -e .
 
-# 2) Optional: ingest docs for RAG
-python scripts/ingest_docs.py
+# 2) Optional: vector RAG (ingest feeds the Chroma store used by RAG_BACKEND=vector)
+python scripts/ingest_docs.py   # then set RAG_BACKEND=vector in .env
 
 # 3) Run locally
 uvicorn app.main:app --host 0.0.0.0 --port 8000
@@ -115,7 +116,8 @@ Backend flags apply unchanged (`RAG_BACKEND`, `AGENT_BACKEND`,
 | `app/utils/` | Audit, RBAC, cost tracking, prompt registry |
 | `db/` | SQLAlchemy models and migrations |
 | `ml/` | ML training, drift, and registry scripts |
-| `scripts/` | Utilities (ingestion, retention sweep, OpenAPI export) |
+| `scripts/` | Utilities (ingestion, retention sweep, OpenAPI export) and the eval pipeline (dataset sync, evaluators, judges, experiment grid) |
+| `eval/` | Golden prompt dataset (`architect_prompts_v2.jsonl`, 26 prompts) |
 | `docs/` | System and feature documentation |
 
 Complete file map → `docs/components.md`
@@ -177,6 +179,20 @@ flowchart LR
 
 ---
 
+## 🧪 Evaluation
+
+Quality is measured, not assumed. The eval stack (all in-repo, reproducible):
+
+- **Golden dataset** — 26 prompts in three sets (grounded core, new features, negative/adversarial hallucination baits), synced idempotently to LangSmith by `scripts/build_langsmith_dataset.py` with per-example expectations as metadata.
+- **Rubric** — 11 deterministic code evaluators (`scripts/langsmith_evaluators.py`: structure, citations-match-expectations, truncation, latency) plus 4 LLM judges (`scripts/langsmith_judges.py`: correctness, groundedness, completeness, actionability), calibrated against the codebase ([calibration note](docs/eval_calibration_2026-07-04.md)).
+- **Experiments** — `scripts/run_experiment_grid.py` A/B-tests config axes on the same dataset. First grid settled `AGENT_BACKEND` and `LLM_MAX_TOKENS` by measurement: [results + screenshots](docs/eval_results/2026-07-04-grid-backend-tokens.md).
+
+The eval loop has already paid for itself: it caught (and verified the fix for) a LangGraph tool-budget bug that silently returned empty plans, and a retrieval self-pollution bug where eval docs were retrieved as grounding context.
+
+Plan and backlog: [docs/langsmith_test_plan.md](docs/langsmith_test_plan.md), [docs/langsmith_eval_backlog.md](docs/langsmith_eval_backlog.md).
+
+---
+
 ## 🔒 Governance & Observability
 - **Audit rows** per request (role, hashes, latency, flags)
 - **RBAC** via `X-User-Role` (`guest`, `analyst`, `admin`)
@@ -193,7 +209,7 @@ Full details → `docs/observability.md`, `docs/security.md`
 |-------|--------|--------|
 | 0–2 | Core APIs, retrieval (keyword baseline), Audit, Metrics | ✅ Done |
 | 3–4 | Orchestration (deterministic planner), RBAC, Grafana, Deploy Recipes | ✅ Done |
-| 5–6 | PII detection, Risk ML integration, Router v2 | 🚧 In Progress |
+| 5–6 | PII detection, Risk ML integration, Router v2 | ✅ Done |
 | 7–8 | Memory (short + long term) | ✅ Done |
 | 9 | Architect agent on LangGraph (`AGENT_BACKEND=langgraph`) | ✅ Done |
 | 10 | Real vector retrieval (`RAG_BACKEND=vector`), LiteLLM cost tracking, MCP server | ✅ Done |

--- a/docs/MODERNIZATION_PLAN.md
+++ b/docs/MODERNIZATION_PLAN.md
@@ -36,10 +36,11 @@ and G below), not as standalone design docs.
 
 ## Locked decisions
 
-- **Agent (PR F): build a real LangGraph agent.** The architect currently runs
-  a deterministic planner. Rather than stop there, we implement a genuine
-  tool-loop agent on LangGraph behind `AGENT_BACKEND`, keeping the
-  deterministic planner as the default/offline path.
+- **Agent (PR F): build a real LangGraph agent.** Shipped: a genuine tool-loop
+  agent on LangGraph behind `AGENT_BACKEND=langgraph`, with the deterministic
+  planner as the default/offline path (ADR-0007). A measured comparison later
+  found langgraph wins on groundedness and latency
+  (docs/eval_results/2026-07-04-grid-backend-tokens.md).
 - **LangChain (PR D): drop it, keep only `langchain-core`.** Native structured
   outputs remove the need for the heavyweight package; `langchain-core` stays
   only for typed output parsers. This also retires the stale
@@ -47,20 +48,22 @@ and G below), not as standalone design docs.
 
 ## PR sequence
 
-| # | Branch | Scope | Docs | Size | Depends on |
-|---|--------|-------|------|------|------------|
-| 0 | `ci/health` | Fix MLflow file-store opt-out and regenerate the OpenAPI schema so CI is green for everything after. | testing.md | S | — |
-| A | `docs/scope-and-roadmap` | Scope statement, roadmap refresh, this plan, build-vs-buy ADR. No code behavior change. | ADR-0004, README | S | — |
-| B | `refactor/rag-naming` | Rename `langchain_rag.py` → `doc_retriever.py` to match what it does; retire placeholder response paths. | rag.md | S | A |
-| C | `feat/vector-rag` | Real embeddings (sentence-transformers) + Chroma retrieval behind `RAG_BACKEND`; keep deterministic baseline as fallback; wire `ingest_docs.py`; golden-query tests. | rag.md, rag_vector_backends.md | L | B |
-| D | `refactor/structured-outputs` | Replace `parse_json_safe` with native structured outputs / tool-use; drop `langchain` to `langchain-core`. | ADR | M | — |
-| E | `feat/litellm-client` | Swap the hand-rolled multi-provider client for LiteLLM (keep the `stub` provider); wire real per-model `cost_usd` into the FinOps metrics. | observability.md | M | — |
-| F | `feat/langgraph-architect` | Real LangGraph tool-loop agent behind `AGENT_BACKEND`; deterministic builtin planner stays the default. | ADR, agents.md | L | C, D |
-| G | `feat/mcp-server` | Expose the tools/architect over MCP. | ADR, README | M–L | C, E |
-| H | `feat/pii-presidio` | Presidio detector behind a flag; regex baseline kept. | ADR | M | — |
-| I | `ci/coverage-gate` | Add a coverage gate and restore the coverage badge; run new tests. | — | S | — |
+| # | Branch | Scope | Docs | Size | Depends on | Status |
+|---|--------|-------|------|------|------------|--------|
+| 0 | `ci/health` | Fix MLflow file-store opt-out and regenerate the OpenAPI schema so CI is green for everything after. | testing.md | S | — | ✅ |
+| A | `docs/scope-and-roadmap` | Scope statement, roadmap refresh, this plan, build-vs-buy ADR. No code behavior change. | ADR-0004, README | S | — | ✅ |
+| B | `refactor/rag-naming` | Rename `langchain_rag.py` → `doc_retriever.py` to match what it does; retire placeholder response paths. | rag.md | S | A | ✅ |
+| C | `feat/vector-rag` | Real embeddings (sentence-transformers) + Chroma retrieval behind `RAG_BACKEND`; keep deterministic baseline as fallback; wire `ingest_docs.py`; golden-query tests. | rag.md, rag_vector_backends.md | L | B | ✅ |
+| D | `refactor/structured-outputs` | Replace `parse_json_safe` with native structured outputs / tool-use; drop `langchain` to `langchain-core`. | ADR | M | — | ✅ |
+| E | `feat/litellm-client` | Swap the hand-rolled multi-provider client for LiteLLM (keep the `stub` provider); wire real per-model `cost_usd` into the FinOps metrics. | observability.md | M | — | ✅ |
+| F | `feat/langgraph-architect` | Real LangGraph tool-loop agent behind `AGENT_BACKEND`; deterministic builtin planner stays the default. | ADR, agents.md | L | C, D | ✅ |
+| G | `feat/mcp-server` | Expose the tools/architect over MCP. | ADR, README | M–L | C, E | ✅ |
+| H | `feat/pii-presidio` | Presidio detector behind a flag; regex baseline kept. | ADR | M | — | ✅ |
+| I | `ci/coverage-gate` | Add a coverage gate and restore the coverage badge; run new tests. | — | S | — | ✅ |
 
-**Recommended order:** 0 → A → B → C → D → E → F, then optional G / H / I.
+**All PRs above have shipped.** Since then the repo also gained a LangSmith
+eval pipeline (golden dataset, code evaluators, calibrated LLM judges,
+experiment grid — see docs/langsmith_test_plan.md and docs/eval_results/).
 
 ## Status legend
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,15 @@ Core topics
 - security.md: RBAC, PII, and retention
 - ml.md, mlops_plan.md: MLflow, drift, and lifecycle
 - feature_store_quality.md: vendor-neutral feature store design and data quality checks
-- testing.md: local tests, e2e flows, and CI tips
+- testing.md: local tests, e2e flows, CI tips, and the 75% coverage gate
+
+Evaluation (LangSmith)
+- langsmith_test_plan.md: the eval strategy (dataset, rubric, experiments, online eval)
+- langsmith_eval_backlog.md: work items LS-1..13 with statuses
+- eval_prompt_set_v2.md: the 26-prompt golden dataset (grounded core, new features, adversarial)
+- eval_calibration_2026-07-04.md: judge calibration round 1, with the disagreement table
+- eval_results/: dated experiment writeups with screenshots (first: backend x token grid)
+- live_eval.md: legacy smoke-check script (superseded for quality evaluation)
 
 Artifacts and references
 - data_card.md, model_card.md: documentation templates

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -15,10 +15,18 @@ The `/architect` endpoints run one of two backends, selected by
   LLM decides each turn whether to call the `retrieve_docs` tool (backed by
   `doc_retriever`, so `RAG_BACKEND=vector` applies) or finalize the plan.
   Tool observations feed back into the next turn; the loop is capped at 3
-  tool calls. Tokens and cost accumulate across turns into the audit, which
-  also reports `agent_backend` and `agent_tool_calls`. Any failure falls
-  back to the builtin planner. Memory read/write integration is
-  builtin-only for now (ADR 0007).
+  tool calls. When the budget is exhausted the agent receives an explicit
+  finalize-now instruction, and a plan that still comes back empty raises so
+  the builtin fallback fires instead of streaming an empty plan. Tokens and
+  cost accumulate across turns into the audit, which also reports
+  `agent_backend` and `agent_tool_calls`. Any failure falls back to the
+  builtin planner. Memory read/write integration is builtin-only for now
+  (ADR 0007).
+
+In a measured comparison on the golden eval dataset, `langgraph` beat
+`builtin` on groundedness, correctness, completeness AND latency, so the
+default is the offline-safe choice, not necessarily the recommended one.
+See `docs/eval_results/2026-07-04-grid-backend-tokens.md`.
 
 Architect agent and community loop
 - The Architect agent can propose features when it detects gaps between a user goal and current capabilities (e.g., a new endpoint or a router rule).

--- a/docs/api.md
+++ b/docs/api.md
@@ -122,6 +122,10 @@ Request: { question: str, grounded?: bool, user_id?: str, session_id?: str, inte
   - Defaults: steps defaults to [search, fetch, summarize, risk_check]
   - Flags: AGENT_LIVE_MODE, AGENT_URL_ALLOWLIST, DENYLIST
   - See docs/agents.md for step details
+- POST /think — think planner: structured intermediate reasoning ahead of an
+  Architect plan (analyst/admin)
+  - Request: { request_type: "ThinkRequest"|"ToolResult", ... }
+  - Response: planner output plus audit (tokens/cost/latency)
 
 ## Router Agent
 

--- a/docs/architect_deterministic_mode.md
+++ b/docs/architect_deterministic_mode.md
@@ -1,5 +1,11 @@
 # Architect Deterministic Mode (LangGraph)
 
+> **Historical proposal — superseded.** LangGraph shipped as a different
+> design: an opt-in tool-loop agent behind `AGENT_BACKEND=langgraph` (see
+> docs/agents.md and ADR-0007), not the concurrent-pipeline mode described
+> here. The `/architect/final` endpoint proposed below was never built. Kept
+> for design history.
+
 Problem
 - Current SSE streaming delivers partial content (summary, steps, flags, citations) as events arrive. It can feel disjointed and requires UI tricks (typing, buffering) to appear coherent.
 - We want a mode that executes sub-tasks concurrently but returns a single cohesive deliverable at the end.

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -4,6 +4,11 @@
 - Function: app.utils.audit.write_audit
 - Non-blocking behavior: DB errors are caught, transaction rolled back, and error logged. API flow continues.
 - Fields include: request_id, endpoint, user_id, created_at, tokens_prompt/completion, cost_usd, latency_ms, compliance_flag, prompt_hash, response_hash.
+- Per-feature extras ride along in the audit payload: rag_backend (+ query-expansion flags on the keyword path), agent_backend and agent_tool_calls (architect), llm_provider/llm_model/llm_cost_usd (real cost from LiteLLM's pricing map), memory_* counters, router_backend/router_intent, pii extras.
+
+## Tracing (LangSmith)
+- Architect requests emit a LangSmith RunTree when LANGCHAIN_TRACING_V2=true and LANGCHAIN_API_KEY is set; runs land in the LANGCHAIN_PROJECT project.
+- The eval pipeline builds on the same integration; see docs/langsmith_test_plan.md.
 
 ## Database
 - SQLite by default; configure DB_URL for other engines.

--- a/docs/capabilities_current.md
+++ b/docs/capabilities_current.md
@@ -28,9 +28,9 @@ Endpoints and behaviors
   - Audit: step entries with inputs/outputs preview and latency
 - POST /policy_navigator — decomposes question, retrieves citations, and synthesizes a recommendation
   - Flags: POLICY_NAV_ENABLED (default true), POLICY_NAV_MAX_SUBQS
-- POST /pii — deterministic PII detection (regex + heuristics), optional grounded citations
+- POST /pii — PII detection (regex + heuristics baseline, Presidio NER behind PII_BACKEND=presidio), optional grounded citations
   - Request: {text, types?, grounded?}; Response: summary, entities, counts, types_present, audit
-  - Env: PII_TYPES, PII_LOCALES override active detectors
+  - Env: PII_BACKEND (regex|presidio), PII_TYPES, PII_LOCALES override active detectors
 - POST /pii_remediation — synthesizes remediation suggestions for detected PII
   - Flags: PII_REMEDIATION_ENABLED (default true), PII_REMEDIATION_INCLUDE_SNIPPETS
 - POST /predict and GET /predict/schema — MLflow-backed predictions
@@ -100,12 +100,18 @@ Configuration highlights (env)
 - POLICY_NAV_ENABLED, POLICY_NAV_MAX_SUBQS
 - PII_REMEDIATION_ENABLED, PII_REMEDIATION_INCLUDE_SNIPPETS, PII_TYPES, PII_LOCALES
 
+Shipped since this baseline was written (see CHANGELOG for details)
+- MCP server (`app/mcp_server.py`, tools: retrieve_docs, detect_pii, architect_plan)
+- Vector retrieval backend (Chroma, `RAG_BACKEND=vector`)
+- LangGraph tool-loop architect (`AGENT_BACKEND=langgraph`)
+- Presidio PII backend (`PII_BACKEND=presidio`)
+- LangSmith eval pipeline (golden dataset, evaluators, judges, experiment grid)
+
 Out of scope (to design next, separately)
 - PEFT/LoRA/QLoRA fine-tuning and adapter loading
 - RLHF/DPO and bandit-based routing
-- MCP server/client and tool adapters
 - gRPC + streaming RPCs and WebSockets
 - Streaming and batch ingestion pipelines; schedulers (Airflow/Prefect)
 - Feature store (Feast) and data quality (Great Expectations) with lineage (OpenLineage/DataHub)
-- Vector DB backends and hybrid search; rerankers
+- Hybrid search and rerankers; managed vector DB backends (Pinecone)
 - OpenTelemetry tracing, semantic caching, cost governance, multi-tenant isolation

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,32 +1,80 @@
 # Configuration
 
-Environment variables (selected):
+Environment variables (selected). Defaults shown are the code defaults when the
+variable is unset; `.env.example` documents a working local setup.
+
+## Core
 
 - APP_ENV: runtime profile (default: local)
 - LOG_LEVEL: logging level (default: INFO)
 - REQUEST_ID_HEADER: request ID header name (default: X-Request-ID)
 - METRICS_TOKEN: if set, /metrics requires header X-Metrics-Token with this value
-- DB_URL: database URL (default: sqlite:////data/audit.db)
-- VECTORSTORE_PATH: path for vector store persistence
-- DOCS_PATH: path to example docs for ingestion
-- EMBEDDINGS_PROVIDER: local|openai|stub
-- EMBEDDINGS_MODEL: sentence-transformers model or OpenAI embedding model name
-- ROUTER_ENABLED: enable simple Router Agent (rules-based) to select intent (default: false)
-- PII_TYPES: comma-separated list of detectors to enable (default: email,phone,ssn,credit_card,ipv4)
-- RISK_ML_ENABLED: flag to use the deterministic ML-like risk scorer instead of heuristics (default: false)
+- DB_URL: database URL (default: sqlite:///./audit.db)
+
+## Backends (the headline switches)
+
+- AGENT_BACKEND: builtin|langgraph — architect implementation (default: builtin;
+  langgraph won the measured comparison, see docs/eval_results/)
+- RAG_BACKEND: keyword_scan|vector — retrieval path (default: keyword_scan;
+  vector uses the Chroma store fed by scripts/ingest_docs.py)
+- PII_BACKEND: regex|presidio — PII detector engine (default: regex)
+- ROUTER_ENABLED: enable the rules-based Router Agent for intent selection (default: false)
+- ROUTER_BACKEND, ROUTER_RULES_JSON, ROUTER_RULES_PATH: router implementation and rules override
+
+## LLM
+
+- LLM_PROVIDER: stub|openai|... (default: stub, deterministic offline; real providers route through LiteLLM)
+- LLM_MODEL, LLM_TEMPERATURE, LLM_MAX_TOKENS (default: 512)
+- LLM_ENABLE_QUERY, LLM_ENABLE_ARCHITECT: opt LLM synthesis into /query and /architect (default: false)
+- PROJECT_GUIDE_ENABLED: gates the /architect endpoint (default: false)
+- OPENAI_API_KEY and other provider keys: read by LiteLLM at call time
+
+## Retrieval
+
+- DOCS_PATH: corpus root. Careful: the keyword-scan query path defaults to ./examples
+  while scripts/ingest_docs.py defaults to ./docs — set it explicitly
+- VECTORSTORE_PATH: Chroma persistence path; RAG_COLLECTION: collection name
+- RAG_EXCLUDE_FILES: comma-separated basenames never used as grounding context
+  (defaults include the eval/prompt docs; applied at keyword scan, vector query, and ingestion)
+- RAG_MULTI_QUERY_ENABLED, RAG_MULTI_QUERY_COUNT, RAG_HYDE_ENABLED: query expansion
+  (keyword-scan path only; no-ops under RAG_BACKEND=vector)
+- EMBEDDINGS_PROVIDER: local|openai|hash|stub
+- LOCAL_EMBEDDING_MODEL (default: all-MiniLM-L6-v2), OPENAI_EMBEDDING_MODEL (default: text-embedding-ada-002)
+
+## PII / Risk
+
+- PII_TYPES: comma-separated detectors (default: email,phone,ssn,credit_card,ipv4); PII_LOCALES
+- PII_PRESIDIO_THRESHOLD (default: 0.5), PII_SPACY_MODEL (default: en_core_web_sm): presidio backend knobs
+- RISK_ML_ENABLED: ML-style risk scorer instead of heuristics (default: false); RISK_THRESHOLD (default: 0.6)
+
+## Memory
+
 - MEMORY_SHORT_ENABLED: enable short-term memory (default: false)
 - MEMORY_DB_PATH: SQLite path for short memory (default: ./data/memory_short.db)
 - MEMORY_SHORT_MAX_TURNS: max turns before summary (default: 10)
-- SHORT_MEMORY_RETENTION_DAYS: prune short-term turns older than N days (default: 0=disabled)
-- SHORT_MEMORY_MAX_TURNS_PER_SESSION: cap short-term turns per session (default: 0=disabled)
-- MEMORY_LONG_ENABLED: enable long-term memory (default: false)
-- MEMORY_COLLECTION_PREFIX: long-memory collection prefix (default: memory)
-- MEMORY_LONG_RETENTION_DAYS: prune facts older than N days (default: 0=disabled)
-- MEMORY_LONG_MAX_FACTS: keep at most N facts per user (default: 0=disabled)
-- MLFLOW_TRACKING_URI, MLFLOW_EXPERIMENT_NAME: MLflow configuration
+- SHORT_MEMORY_RETENTION_DAYS, SHORT_MEMORY_MAX_TURNS_PER_SESSION (default: 0=disabled)
+- MEMORY_LONG_ENABLED (default: false), MEMORY_COLLECTION_PREFIX (default: memory)
+- MEMORY_LONG_RETENTION_DAYS, MEMORY_LONG_MAX_FACTS (default: 0=disabled)
+- Note: memory integrates with /query and the builtin architect; the langgraph backend currently bypasses it
+
+## Research agent safety
+
+- AGENT_LIVE_MODE: allow live HTTP fetch in /research (default: false)
+- AGENT_URL_ALLOWLIST, DENYLIST: fetch allowlist and risk-check denylist
+
+## ML / MLflow
+
+- MLFLOW_TRACKING_URI, MLFLOW_EXPERIMENT_NAME (default: ai-architect)
+- MLFLOW_MODEL_URI, MLFLOW_MODEL_ARTIFACT_PATH, MLFLOW_FEATURE_ORDER_ARTIFACT, MLFLOW_MODEL_CACHE_TTL
 - ML_BASELINE_DATA, ML_INPUT_DATA: paths for drift script defaults
 
-See .env.example for a complete list and defaults.
+## Tracing / Eval
+
+- LANGCHAIN_TRACING_V2 + LANGCHAIN_API_KEY: enable LangSmith tracing (both required)
+- LANGCHAIN_PROJECT: LangSmith project runs land in
+- EVAL_JUDGE_MODEL: LLM-judge model for the eval pipeline (default: gpt-4.1-mini)
+
+See .env.example for a working local setup.
 
 Install notes:
 - CPU-only Docker builds install sentence-transformers using the PyTorch CPU wheel index so torch resolves to CPU wheels.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,7 +10,7 @@ Prerequisites
 Quickstart (local)
 ```bash
 # 0) Clone & env
-git clone https://github.com/rodrigo-fonseca-oliveira/ai-architect
+git clone https://github.com/bridge-intelligence-lab/ai-architect
 cd ai-architect
 cp .env.example .env  # fill in only if using hosted LLMs; local defaults work
 
@@ -19,9 +19,11 @@ python -m venv .venv
 . .venv/bin/activate
 pip install -e .
 
-# 2) (Optional) Ingest docs for RAG (LangChain mode)
-# Place .md/.txt/.pdf into DOCS_PATH (defaults to ./docs)
+# 2) (Optional) Vector RAG: ingest docs into the Chroma store
+# Place .md/.txt/.pdf into DOCS_PATH (ingest defaults to ./docs; note the
+# keyword-scan query path defaults to ./examples, so set DOCS_PATH explicitly)
 python scripts/ingest_docs.py
+# then set RAG_BACKEND=vector in .env to use the ingested store
 
 # 3) Run API
 uvicorn app.main:app --host 0.0.0.0 --port 8000
@@ -38,8 +40,8 @@ Architect UI
 - Architect-first experience with streaming and debug panel
 
 RAG basics
-- Default in tests/CI: deterministic retriever (no embeddings network calls)
-- To use LangChain locally: set LC_RAG_BACKEND=langchain and run scripts/ingest_docs.py
+- Default in tests/CI: deterministic keyword-scan retriever (no embeddings network calls)
+- For vector retrieval locally: run scripts/ingest_docs.py, then set RAG_BACKEND=vector
 - See docs/rag.md and docs/rag_vector_backends.md for flags and backends
 
 Observability stack (optional)
@@ -56,28 +58,20 @@ make test
 ```
 
 Troubleshooting
-- Missing citations in deterministic mode: ensure DOCS_PATH points to your docs folder and files are .md/.txt/.pdf
-- Vector store not found in LangChain mode: check VECTORSTORE_PATH and re-run scripts/ingest_docs.py
+- Missing citations in deterministic mode: ensure DOCS_PATH points to your docs folder and files are .md/.txt/.pdf (the keyword-scan path defaults to ./examples when DOCS_PATH is unset)
+- Vector store not found with RAG_BACKEND=vector: check VECTORSTORE_PATH and re-run scripts/ingest_docs.py (retrieval falls back to keyword scan when the store is missing or empty)
 - Protected endpoints (RBAC): use X-User-Role: analyst for grounded /query and admin-only routes
 
-LiteLLM gateway (OpenAI-compatible)
-- To route LLM calls via LiteLLM, set:
-  - LLM_PROVIDER=openai
-  - OPENAI_BASE_URL=http://<your-litellm-host>:<port>/v1
-  - LLM_API_KEY=<token-if-required>
-  - LLM_MODEL=<alias-configured-in-LiteLLM>
-  - EMBEDDINGS_PROVIDER=openai (if embeddings proxied)
-  - EMBEDDINGS_MODEL=<embeddings-alias>
-- Docker Compose snippet:
-  services:
-    app:
-      environment:
-        - LLM_PROVIDER=openai
-        - OPENAI_BASE_URL=http://litellm:4000/v1
-        - LLM_API_KEY=sk-litellm-any
-        - LLM_MODEL=gpt-4o-mini
-        - EMBEDDINGS_PROVIDER=openai
-        - EMBEDDINGS_MODEL=text-embedding-3-small
+LLM providers (via LiteLLM)
+- All real providers route through the LiteLLM library natively; there is no
+  separate gateway to configure. Set:
+  - LLM_PROVIDER=openai (or another LiteLLM-supported provider; `stub` = offline default)
+  - LLM_MODEL=<model name, e.g. gpt-4.1-mini>
+  - OPENAI_API_KEY=<your key> (provider keys are read by LiteLLM at call time)
+- Embeddings are configured separately: EMBEDDINGS_PROVIDER=local|openai|hash|stub,
+  with LOCAL_EMBEDDING_MODEL (default all-MiniLM-L6-v2) or OPENAI_EMBEDDING_MODEL
+  (default text-embedding-ada-002)
+- Per-request cost comes from LiteLLM's pricing map and lands in audit rows and /metrics
 
 Next steps
 - Explore the API: docs/api.md

--- a/docs/ingestion_pipelines.md
+++ b/docs/ingestion_pipelines.md
@@ -94,8 +94,11 @@ Quality and governance
 - Privacy: PII redaction gates before embedding/indexing.
 
 Rollout plan
+- Shipped (outside this plan): scripts/ingest_docs.py is the real batch
+  ingestion CLI today — chunking (1000/200), idempotent path+offset ids,
+  Chroma upserts, RAG_EXCLUDE_FILES skip, `make ingest` entry point.
 - Phase 1: Documentation (this file) and align with ports_and_adapters.md.
-- Phase 2: CLI scaffolding:
+- Phase 2: CLI scaffolding (not yet built):
   - scripts/batch_ingest_docs.py (JSONL/Parquet artifacts, optional local vector store upserts)
   - scripts/stream_worker.py (local dir queue; optional Kafka/NATS if configured)
 - Phase 3: Adapters and metrics: add Bus adapters, MetadataStore (SQLite/Postgres), Prom metrics, DLQ handling.

--- a/docs/live_eval.md
+++ b/docs/live_eval.md
@@ -1,5 +1,11 @@
 # Live Evaluation for Architect (HTTP + httpx)
 
+> **Superseded for quality evaluation.** This script (`run_live_eval.py`) is the
+> legacy smoke-check path. Systematic quality evaluation now runs through the
+> LangSmith pipeline: golden dataset, code evaluators, calibrated LLM judges,
+> and experiments — see `docs/langsmith_test_plan.md` and `docs/eval_results/`.
+> This doc remains valid for a quick local smoke run.
+
 This guide shows how to run a live evaluation of the Architect agent using the real OpenAI API and your running service. It streams from the `/architect/stream` endpoint (SSE), measures simple quality metrics, and optionally logs runs to LangSmith for observability.
 
 ## Prerequisites

--- a/docs/llm_agent_streaming_prompts.md
+++ b/docs/llm_agent_streaming_prompts.md
@@ -1,5 +1,12 @@
 # LLM Agent Streaming Test Prompts
 
+> **Scope note.** These prompts are for exercising the streaming UI by hand.
+> For evaluation they are superseded by `docs/eval_prompt_set_v2.md` /
+> `eval/architect_prompts_v2.jsonl` (the LangSmith golden dataset). This file
+> is deliberately excluded from the RAG corpus via `RAG_EXCLUDE_FILES` — it
+> contains the eval questions verbatim and would otherwise be retrieved as
+> "context" for them.
+
 Use these prompts to exercise different parts of the system and the streaming UI. They are grouped by scenario. Paste them into the Architect UI or call the streaming endpoint.
 
 Streaming endpoint

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -27,6 +27,11 @@ Integration in /query
 - Retrieved long-term facts are added as a contextual preamble
 - After answering, writes user and assistant turns; ingests long facts into long-term memory
 
+Integration in /architect
+- The builtin architect backend integrates the same way (same flags, same
+  memory_* audit counters); see docs/agents.md
+- The langgraph backend currently bypasses memory entirely (counters report 0)
+
 Configuration
 - MEMORY_SHORT_ENABLED: false
 - MEMORY_DB_PATH: ./data/memory_short.db

--- a/docs/ports_and_adapters.md
+++ b/docs/ports_and_adapters.md
@@ -28,10 +28,11 @@ Key ports (initial focus first, others later)
   - LlamaIndexAdapter (planned/optional): QueryEngines, HyDE, rerank, rich metadata
   - HaystackAdapter (planned/optional): Pipelines with BM25+dense, rankers, evaluation
 - Selection env
-  - Preferred: RAG_BACKEND=deterministic|langchain|llamaindex|haystack
-  - Back-compat alias: LC_RAG_BACKEND (if set, it maps to RAG_BACKEND)
+  - Shipped: RAG_BACKEND=keyword_scan|vector (Chroma; see rag.md). The
+    langchain/llamaindex/haystack adapter values and the LC_RAG_BACKEND alias
+    described in this design were never implemented.
 - Default behavior
-  - DeterministicAdapter in CI/tests for stability; production may opt into LangChain or others.
+  - Keyword-scan adapter in CI/tests for stability; production may opt into the vector backend.
 
 2) AgentPlannerPort (architect/policy planning)
 - Responsibilities
@@ -71,11 +72,10 @@ Key ports (initial focus first, others later)
 7) MemoryPort (optional wrapper)
 - Thin wrapper around existing short/long memory so agents can call memory uniformly via ToolPort.
 
-Env/config conventions
-- RAG_BACKEND: deterministic|langchain|llamaindex|haystack (preferred)
-- LC_RAG_BACKEND: legacy alias; mapped into RAG_BACKEND if present
-- AGENT_BACKEND: builtin|langchain|semantic_kernel|crewai (default: builtin)
-- EMBEDDINGS_PROVIDER: stub|local|openai (default: stub/local for determinism)
+Env/config conventions (as shipped; this design doc predates implementation)
+- RAG_BACKEND: keyword_scan|vector (default: keyword_scan)
+- AGENT_BACKEND: builtin|langgraph (default: builtin)
+- EMBEDDINGS_PROVIDER: local|openai|hash|stub (default: local)
 - VECTORSTORE_BACKEND (future): chroma|faiss|pinecone|pgvector|weaviate
 - TRACE_BACKEND: none|langsmith|otel
 - Flags used by RAG options: RAG_MULTI_QUERY_ENABLED, RAG_MULTI_QUERY_COUNT, RAG_HYDE_ENABLED

--- a/docs/project_guide_rag.md
+++ b/docs/project_guide_rag.md
@@ -1,5 +1,12 @@
 # Project Guide RAG and Solution Architect Mode
 
+> **Status: largely shipped.** Phases A-C below landed: the guide is the
+> `/architect` endpoint gated by `PROJECT_GUIDE_ENABLED` (there is no
+> `guide=true` payload flag), brainstorm is a UI mode, and docs ingestion
+> shipped via `scripts/ingest_docs.py` with eval docs excluded through
+> `RAG_EXCLUDE_FILES`. The implementation-plan sections are kept as design
+> history.
+
 Note: For the MLOps roadmap (model registry, data and model drift, and serving), see docs/mlops_plan.md.
 
 Purpose

--- a/docs/rag.md
+++ b/docs/rag.md
@@ -25,14 +25,23 @@ no placeholder content is fabricated.
 ## Ingestion (vector backend)
 
 1. Place `.md`/`.txt`/`.pdf` files under `DOCS_PATH`
-2. Run `python scripts/ingest_docs.py` (chunks of 1000 chars with 200
-   overlap; idempotent, ids derive from path + offset)
+2. Run `python scripts/ingest_docs.py` or `make ingest` (chunks of 1000 chars
+   with 200 overlap; idempotent, ids derive from path + offset; files in
+   `RAG_EXCLUDE_FILES` are skipped)
 3. Set `RAG_BACKEND=vector` and query with `grounded=true`
 
 ## Environment flags
 
 - `RAG_BACKEND=keyword_scan|vector` (default: `keyword_scan`)
-- `DOCS_PATH=./docs` — corpus root
+- `DOCS_PATH` — corpus root. Careful: the keyword-scan query path defaults to
+  `./examples` while `scripts/ingest_docs.py` defaults to `./docs`; set it
+  explicitly so both paths agree
+- `RAG_EXCLUDE_FILES` — comma-separated basenames never used as grounding
+  context. The default excludes the eval/test-prompt docs (they contain the
+  eval questions verbatim and would otherwise be retrieved as "context" for
+  them). Enforced at all three paths: keyword scan, vector query (over-fetches
+  2x then drops excluded chunks, so an already-built store behaves), and
+  ingestion
 - `VECTORSTORE_PATH=./.local/vectorstore` — Chroma persistence dir
 - `RAG_COLLECTION=docs` — Chroma collection name
 - `EMBEDDINGS_PROVIDER=local|hash|stub` — `local` uses
@@ -45,7 +54,8 @@ no placeholder content is fabricated.
   (keyword-scan path)
 
 The audit record reports `rag_backend` as the backend actually used
-(`keyword_scan` or `vector`), plus the query-expansion flags.
+(`keyword_scan` or `vector`). The query-expansion flags are reported only when
+the keyword-scan path runs (they are no-ops under `vector`).
 
 ## Testing
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,9 +40,25 @@ METRICS_TOKEN=secret \
 ## Keyword expression
 .venv/bin/python -m pytest -k "rag and idempotent"
 
-## Coverage (optional)
+## Coverage (enforced in CI)
+CI runs the suite with a hard coverage gate: line coverage of `app/` and
+`scripts/` must be at least **75%** or the build fails
+(`pytest -q --cov=app --cov=scripts --cov-fail-under=75`, see
+`.github/workflows/ci.yml`). To reproduce locally:
+
 pip install pytest-cov
-.venv/bin/python -m pytest --cov=app --cov=ml --cov=db --cov-report=term-missing
+.venv/bin/python -m pytest --cov=app --cov=scripts --cov-report=term-missing --cov-fail-under=75
+
+## Offline by default
+`tests/conftest.py` pins the stub LLM provider (and related env) for every
+test, so a populated local `.env` cannot leak a real provider key into the
+suite. Test runs make no billed API calls; keep new tests deterministic and
+offline.
+
+## Quality evaluation (separate from unit tests)
+Answer-quality regression is handled by the LangSmith eval pipeline (golden
+dataset + code evaluators + calibrated LLM judges), not pytest. See
+`docs/langsmith_test_plan.md` and `docs/eval_results/`.
 
 ## Lint/format (optional)
 pip install ruff


### PR DESCRIPTION
Output of a full docs-vs-code review (13 doc clusters audited by subagents + skeptic verification; ~56 findings, all evidence-backed). Four commits:

1. **Entry points** — README status paragraph no longer contradicts its own roadmap table (vector RAG, LangGraph agent, LiteLLM cost all shipped), phase 5-6 marked done, new **Evaluation** section; getting_started drops dead `LC_RAG_BACKEND`/LangChain-mode vocabulary, fixes the clone org, and rewrites the LLM-provider section around vars the code actually reads; config.md documents the real config surface (correct DB_URL default, all headline switches, the `DOCS_PATH` divergent-default gotcha).
2. **.env.example** — adds ~18 shipped vars (AGENT_BACKEND, RAG_BACKEND, PII_BACKEND, RAG_EXCLUDE_FILES, EVAL_JUDGE_MODEL, router/risk/research/MLflow/embeddings), removes 4 vars no code reads (LC_RAG_ENABLED, LLM_ENABLE_RESEARCH, PII_REMEDIATION_INCLUDE_SNIPPETS, LANGCHAIN_TRACING_SESSION_NAME), fixes the stub-comment contradiction and MLFLOW_EXPERIMENT_NAME.
3. **Living-doc gaps** — RAG_EXCLUDE_FILES documented (all 3 enforcement paths), langgraph tool-budget/fallback behavior post-#21, /think added to api.md, testing.md documents the CI 75% coverage gate (closes the calibration finding that made eval prompt B8 unanswerable) + the conftest stub fixture, superseded banners on live_eval + streaming prompts, eval docs indexed in docs/README.md, capabilities_current moves shipped items out of out-of-scope.
4. **Superseded design docs** — historical banners on architect_deterministic_mode (proposes a /architect/final that never shipped) and project_guide_rag (no guide=true flag), ports_and_adapters aligned to shipped adapter values, MODERNIZATION_PLAN PR table gains a status column (all ✅).

Notable non-finding: getting_started's Grafana :3000 matches the committed compose; the :3001 remap is a local uncommitted change (cognee-frontend holds :3000 on the dev box) and stays local.

Full review notes with file:line evidence available on request. Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)