### PR TITLE
Fire feature CTA on explicit build/collaborate phrasing

### DIFF
--- a/app/services/architect_agent.py
+++ b/app/services/architect_agent.py
@@ -135,15 +135,45 @@ def _save_memory(
     return counters
 
 
+# Explicit build/collaborate phrasing fires the CTA even when the answer is
+# grounded and has steps: with vector RAG + a strong model nearly every answer
+# is grounded, so the sparse-or-ungrounded gate alone never triggers.
+_FEATURE_PHRASES = (
+    "add support",
+    "can you add",
+    "could you add",
+    "can we add",
+    "please add",
+    "can we build",
+    "can you build",
+    "could we build",
+    "build that together",
+    "build this together",
+    "work on this together",
+    "feature request",
+    "new feature",
+    "would be nice",
+    "would be great",
+    "on the roadmap",
+    "do you plan",
+    "any plans",
+    "integrate this with",
+    "integrate it with",
+    "integration with",
+)
+
+
 def _apply_feature_heuristic(plan: ArchitectPlan, question: str) -> None:
-    """Suggest opening a feature request when the ask sounds like new work and
-    the plan came back thin or ungrounded. Backend-agnostic."""
+    """Suggest opening a feature request when the ask sounds like new work:
+    explicit build/collaborate phrasing always fires; broad keywords only fire
+    when the plan came back thin or ungrounded. Backend-agnostic."""
     try:
         ql = (question or "").lower()
+        explicit = any(p in ql for p in _FEATURE_PHRASES)
         needs = any(w in ql for w in ("feature", "support", "integrate", "add", "roadmap"))
         sparse = len(plan.suggested_steps or []) == 0 and len(plan.suggested_env_flags or []) == 0
         grounded_used = bool(getattr(plan, "grounded_used", False))
-        if (sparse or not grounded_used) and needs:
+        if explicit or ((sparse or not grounded_used) and needs):
             plan.suggest_feature = True
             plan.feature_request = plan.feature_request or (
                 f"Request: {question[:60]}" if question else "Feature request"

--- a/tests/test_backend_parity.py
+++ b/tests/test_backend_parity.py
@@ -103,6 +103,61 @@ def test_langgraph_sets_suggest_feature(monkeypatch):
     assert plan.feature_request
 
 
+def test_explicit_feature_phrasing_fires_even_when_grounded(monkeypatch, tmp_path):
+    # A grounded answer WITH steps must still show the CTA when the user
+    # explicitly asks to add/build something (the sparse-or-ungrounded gate
+    # never fires in the full-capacity config).
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "notify.md").write_text("Notifications are dispatched via the metrics pipeline.")
+    monkeypatch.setenv("DOCS_PATH", str(docs))
+    monkeypatch.setenv("AGENT_BACKEND", "langgraph")
+    monkeypatch.setenv("MEMORY_SHORT_ENABLED", "false")
+    monkeypatch.setenv("MEMORY_LONG_ENABLED", "false")
+
+    monkeypatch.setattr(
+        llm_mod.LLMClient,
+        "call",
+        _scripted_llm(
+            [
+                json.dumps({"action": "retrieve_docs", "query": "notifications"}),
+                _final("Grounded plan.", steps=["step one"], flags=["FLAG=1"]),
+            ]
+        ),
+    )
+
+    plan, _ = run_architect_agent("Can you add support for Slack notifications?")
+    assert plan.grounded_used is True
+    assert plan.suggested_steps  # not sparse
+    assert plan.suggest_feature is True
+
+
+def test_plain_qa_with_add_keyword_does_not_fire_when_grounded(monkeypatch, tmp_path):
+    # Bare keywords ("add") in an ordinary grounded how-to must NOT show the CTA.
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "config.md").write_text("Env vars are added to .env and loaded at startup.")
+    monkeypatch.setenv("DOCS_PATH", str(docs))
+    monkeypatch.setenv("AGENT_BACKEND", "langgraph")
+    monkeypatch.setenv("MEMORY_SHORT_ENABLED", "false")
+    monkeypatch.setenv("MEMORY_LONG_ENABLED", "false")
+
+    monkeypatch.setattr(
+        llm_mod.LLMClient,
+        "call",
+        _scripted_llm(
+            [
+                json.dumps({"action": "retrieve_docs", "query": "env vars"}),
+                _final("Add the variable to .env.", steps=["edit .env"], flags=[]),
+            ]
+        ),
+    )
+
+    plan, _ = run_architect_agent("How do I add an env var to the config?")
+    assert plan.grounded_used is True
+    assert not plan.suggest_feature
+
+
 def test_builtin_memory_counters_unchanged(monkeypatch, tmp_path):
     # The hoist must not change builtin behavior: same counters, same keys.
     monkeypatch.setenv("AGENT_BACKEND", "builtin")


### PR DESCRIPTION
The CTA fix in #27 restored the code path on langgraph, but the heuristic itself never fired in the full-capacity config: it required the answer to be sparse or ungrounded, and with vector RAG + gpt-4.1 every answer is grounded with steps (verified live: two explicit feature requests produced no `feature` event).

Explicit build/collaborate phrases ("add support", "can we build", "feature request", "integration with", ...) now fire the CTA regardless of groundedness. Bare keywords ("add", "support") keep the old thin-answer gate so ordinary grounded how-tos don't show it.

- Checked all phrases against the golden dataset: zero collisions, so eval outputs are unaffected.
- Tests: explicit phrasing fires when grounded+non-sparse; plain "add an env var" how-to does not. Full suite 181 passed.
- Verified live: `event: feature` now emitted for "Can you add support for Slack notifications...".

🤖 Generated with [Claude Code](https://claude.com/claude-code)