### PR TITLE
Module Design sections, architecture walkthrough, docstrings

### DIFF
--- a/app/memory/long_memory.py
+++ b/app/memory/long_memory.py
@@ -1,3 +1,4 @@
+"""Long-term memory: user facts indexed with embeddings and in-memory cosine retrieval."""
 import hashlib
 import os
 from typing import Any, Dict, List
@@ -26,6 +27,10 @@ def _get_embedder():
 
 
 def retrieve_facts(user_id: str, query: str, top_k: int = 5) -> List[Dict[str, Any]]:
+    """Rank stored facts by cosine similarity to query; pruned by retention days.
+
+    Attaches pruned count to retrieve_facts._last_pruned for downstream visibility.
+    """
     # naive similarity via cosine on local embeddings if available
     facts = _FACT_STORE.get(user_id, [])
     if not facts:
@@ -76,6 +81,10 @@ def retrieve_facts(user_id: str, query: str, top_k: int = 5) -> List[Dict[str, A
 def ingest_fact(
     user_id: str, fact: str, metadata: Dict[str, Any] | None = None
 ) -> bool:
+    """Store fact with embedding and metadata; idempotent upsert by content hash.
+
+    Enforces max-facts-per-user by evicting oldest; attaches eviction count to ingest_fact._last_evicted.
+    """
     emb = _get_embedder()
     try:
         vec = emb.embed([fact])[0]
@@ -125,5 +134,6 @@ def ingest_fact(
 
 
 def clear_long_memory(user_id: str) -> None:
+    """Delete all facts for user."""
     if user_id in _FACT_STORE:
         del _FACT_STORE[user_id]

--- a/app/memory/short_memory.py
+++ b/app/memory/short_memory.py
@@ -1,3 +1,4 @@
+"""Short-term conversation memory: SQLite-backed turns and rolling summaries per user+session."""
 import os
 import sqlite3
 from datetime import datetime
@@ -58,6 +59,10 @@ def init_short_memory(db_path: str | None = None):
 
 
 def load_turns(user_id: str, session_id: str) -> List[Tuple[str, str]]:
+    """Load conversation turns for user+session, pruned by retention days and max-per-session.
+
+    Attaches pruned count to load_turns._last_pruned for downstream visibility.
+    """
     init_short_memory()
     conn = sqlite3.connect(get_db_path(), check_same_thread=False)
     c = conn.cursor()
@@ -137,6 +142,7 @@ def load_turns(user_id: str, session_id: str) -> List[Tuple[str, str]]:
 
 
 def load_summary(user_id: str, session_id: str) -> str:
+    """Retrieve stored summary for user+session; empty string if none exists."""
     init_short_memory()
     conn = sqlite3.connect(get_db_path(), check_same_thread=False)
     c = conn.cursor()
@@ -153,6 +159,7 @@ def load_summary(user_id: str, session_id: str) -> str:
 
 
 def save_turn(user_id: str, session_id: str, role: str, content: str):
+    """Store a single conversation turn (role, content) with timestamp."""
     init_short_memory()
     conn = sqlite3.connect(get_db_path(), check_same_thread=False)
     c = conn.cursor()
@@ -173,6 +180,7 @@ def summarize_context(turns: List[Tuple[str, str]]) -> str:
 
 
 def update_summary_if_needed(user_id: str, session_id: str) -> bool:
+    """Persist rolling summary if turn count exceeds threshold; return True if written."""
     turns = load_turns(user_id, session_id)
     max_turns = get_summary_max_turns()
     if len(turns) > max_turns:
@@ -193,6 +201,7 @@ def update_summary_if_needed(user_id: str, session_id: str) -> bool:
 
 
 def clear_short_memory(user_id: str, session_id: str) -> None:
+    """Delete all turns and summary for user+session."""
     init_short_memory()
     conn = sqlite3.connect(get_db_path(), check_same_thread=False)
     c = conn.cursor()

--- a/app/routers/architect.py
+++ b/app/routers/architect.py
@@ -1,3 +1,5 @@
+"""Architect endpoints: structured plan generation (POST) and HTML UI."""
+
 import os
 import time
 from pathlib import Path
@@ -36,6 +38,10 @@ class ArchitectResponse(BaseModel):
 
 @router.post("/architect", response_model=ArchitectResponse, tags=["Architect"])
 def post_architect(request: Request, payload: ArchitectRequest):
+    """Generate structured plan from question with optional grounded retrieval.
+
+    Requires PROJECT_GUIDE_ENABLED flag. Optional LLM synthesis when LLM_ENABLE_ARCHITECT=true.
+    Audit includes prompt/response hashes and LLM usage when agent runs."""
     # feature flag guard
     if os.getenv("PROJECT_GUIDE_ENABLED", "").lower() not in ("1", "true", "yes", "on"):
         raise HTTPException(status_code=404, detail="Architect mode not enabled")

--- a/app/routers/architect_stream.py
+++ b/app/routers/architect_stream.py
@@ -1,3 +1,5 @@
+"""Architect streaming endpoint: SSE output of plan generation."""
+
 import os
 from typing import AsyncGenerator, Dict, Any
 from fastapi import APIRouter, Request, Query
@@ -55,6 +57,10 @@ async def _gen_sse(plan: Dict[str, Any], audit: Dict[str, Any]) -> AsyncGenerato
     },
 )
 async def stream_architect(request: Request, question: str | None = None, session_id: str | None = None, user_id: str | None = None, llm_model: str | None = None):
+    """Stream the architect plan as SSE events: status first (immediate ack),
+    then meta, summary, steps, flags, citations, optional feature, final audit;
+    a server-side failure emits an error event. Questions under 3 characters get
+    an empty stream (single bare meta event), not an HTTP error."""
     # Defensive guard: no-op stream for empty/short questions
     q = (question or "").strip()
     if len(q) < 3:

--- a/app/routers/architect_ui.py
+++ b/app/routers/architect_ui.py
@@ -1,3 +1,5 @@
+"""Architect UI endpoints: HTML form for architect endpoint."""
+
 import os
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
@@ -10,6 +12,7 @@ templates = Jinja2Templates(directory="app/templates")
 
 @router.get("/architect/ui", response_class=HTMLResponse, tags=["Architect"])
 def get_ui(request: Request):
+    """Serve architect form HTML, gated by PROJECT_GUIDE_ENABLED flag."""
     context = {
         "project_guide_enabled": os.getenv("PROJECT_GUIDE_ENABLED", "").lower() in ("1", "true", "yes", "on"),
     }

--- a/app/routers/memory.py
+++ b/app/routers/memory.py
@@ -1,3 +1,5 @@
+"""Memory endpoints: short-term (per-session turns), long-term (facts), and status/export/import."""
+
 import os
 import time
 from typing import Any, Dict, List, Optional
@@ -27,6 +29,9 @@ class MemoryLongResponse(BaseModel):
 
 @router.get("/memory/short", response_model=MemoryShortResponse)
 def get_short_memory(req: Request, user_id: str, session_id: str):
+    """Retrieve conversation turns and summary for user/session.
+
+    Requires analyst role. Returns empty on disabled flag. Includes pruned count."""
     # RBAC
     role = parse_role(req)
     if role not in ("analyst", "admin"):
@@ -85,6 +90,9 @@ def get_short_memory(req: Request, user_id: str, session_id: str):
 
 @router.delete("/memory/short", response_model=dict)
 def delete_short_memory(req: Request, user_id: str, session_id: str):
+    """Clear turns and summary for user/session.
+
+    Requires analyst role. Idempotent: returns cleared=true when enabled."""
     role = parse_role(req)
     if role not in ("analyst", "admin"):
         raise HTTPException(status_code=403, detail="forbidden")
@@ -124,6 +132,9 @@ def delete_short_memory(req: Request, user_id: str, session_id: str):
 
 @router.get("/memory/long", response_model=MemoryLongResponse)
 def get_long_memory(req: Request, user_id: str, q: Optional[str] = None):
+    """Retrieve facts for user, optionally filtered by query.
+
+    Requires analyst role. Returns empty on disabled flag."""
     role = parse_role(req)
     if role not in ("analyst", "admin"):
         raise HTTPException(status_code=403, detail="forbidden")
@@ -166,6 +177,9 @@ def get_long_memory(req: Request, user_id: str, q: Optional[str] = None):
 
 @router.delete("/memory/long", response_model=dict)
 def delete_long_memory(req: Request, user_id: str):
+    """Clear all facts for user.
+
+    Requires analyst role. Idempotent: returns cleared=true when enabled."""
     role = parse_role(req)
     if role not in ("analyst", "admin"):
         raise HTTPException(status_code=403, detail="forbidden")
@@ -204,6 +218,9 @@ def delete_long_memory(req: Request, user_id: str):
 
 @router.get("/memory/status", response_model=dict)
 def get_memory_status(req: Request):
+    """Inspect memory config, database health, and pruning counters.
+
+    Requires admin role."""
     role = parse_role(req)
     if role != "admin":
         raise HTTPException(status_code=403, detail="forbidden")
@@ -287,6 +304,9 @@ def get_memory_status(req: Request):
 
 @router.get("/memory/long/export", response_model=MemoryLongResponse)
 def export_long_memory(req: Request, user_id: str):
+    """Export all facts for user with retention pruning applied.
+
+    Requires analyst role. Includes embedding presence metadata."""
     role = parse_role(req)
     if role not in ("analyst", "admin"):
         raise HTTPException(status_code=403, detail="forbidden")
@@ -338,6 +358,9 @@ class MemoryImportPayload(BaseModel):
 
 @router.post("/memory/long/import", response_model=dict)
 def import_long_memory(req: Request, user_id: str, payload: MemoryImportPayload):
+    """Ingest facts for user with automatic eviction on size limits.
+
+    Requires analyst role. Tracks evictions triggered during import."""
     role = parse_role(req)
     if role not in ("analyst", "admin"):
         raise HTTPException(status_code=403, detail="forbidden")

--- a/app/routers/metrics.py
+++ b/app/routers/metrics.py
@@ -1,3 +1,5 @@
+"""Metrics and health endpoints: Prometheus /metrics and /healthz."""
+
 import os
 
 from fastapi import APIRouter, Header, HTTPException, Response, status
@@ -14,6 +16,7 @@ METRICS_TOKEN = os.getenv("METRICS_TOKEN", "").strip()
 
 @router.get("/healthz")
 def healthz():
+    """Liveness check: returns ok when the process is up."""
     return {"status": "ok"}
 
 
@@ -31,6 +34,7 @@ def healthz():
 def metrics(
     x_metrics_token: str | None = Header(default=None, alias="X-Metrics-Token")
 ):
+    """Prometheus metrics export (text/plain). Token required if METRICS_TOKEN env set."""
     # If a token is configured, enforce it; otherwise allow open access
     if METRICS_TOKEN:
         if not x_metrics_token or x_metrics_token != METRICS_TOKEN:

--- a/app/routers/pii.py
+++ b/app/routers/pii.py
@@ -1,3 +1,5 @@
+"""PII detection endpoints: identify sensitive data in text."""
+
 import os
 import time
 from typing import List, Optional
@@ -29,6 +31,9 @@ class PiiResponse(BaseModel):
 
 @router.post("/pii", response_model=PiiResponse)
 def post_pii(req: Request, payload: PiiRequest):
+    """Detect PII types in text and return counts by entity type.
+
+    Requires analyst role. Optional grounded citations from policy docs."""
     # RBAC: analyst/admin (minimum analyst)
     # Use dependency function style but we call it here for simplicity
     # If role < analyst, raise 403

--- a/app/routers/pii_remediation.py
+++ b/app/routers/pii_remediation.py
@@ -1,3 +1,5 @@
+"""PII remediation endpoints: generate redaction/anonymization guidance."""
+
 import os
 import time
 from typing import Any, Dict, List, Optional
@@ -24,6 +26,9 @@ class PiiRemediationResponse(BaseModel):
 
 @router.post("/pii_remediation", response_model=PiiRemediationResponse)
 def post_pii_remediation(req: Request, payload: PiiRemediationRequest):
+    """Synthesize remediation steps for detected PII with optional code snippets.
+
+    Requires analyst role. Gated by PII_REMEDIATION_ENABLED flag (default true)."""
     role = parse_role(req)
     if role not in ("analyst", "admin"):
         raise HTTPException(status_code=403, detail="forbidden")

--- a/app/routers/policy.py
+++ b/app/routers/policy.py
@@ -1,3 +1,5 @@
+"""Policy navigator endpoints: decompose and answer compliance questions."""
+
 import os
 import time
 from typing import List, Optional
@@ -27,6 +29,10 @@ class PolicyResponse(BaseModel):
 
 @router.post("/policy_navigator", response_model=PolicyResponse)
 def post_policy_navigator(req: Request, payload: PolicyRequest):
+    """Answer policy questions via decompose-retrieve-synthesize loop.
+
+    Requires analyst role. Gated by POLICY_NAV_ENABLED flag (default true).
+    Audit includes step-by-step latencies and hashes."""
     role = parse_role(req)
     if role not in ("analyst", "admin"):
         raise HTTPException(status_code=403, detail="forbidden")

--- a/app/routers/predict.py
+++ b/app/routers/predict.py
@@ -1,3 +1,5 @@
+"""Prediction endpoints: ML model inference with feature validation."""
+
 import os
 import time
 
@@ -15,7 +17,9 @@ router = APIRouter()
 
 @router.get("/predict/schema", response_model=dict)
 def get_predict_schema(role: str = Depends(require_role("analyst"))):
-    """Return expected feature list and model metadata from latest run."""
+    """Retrieve expected feature order and model metadata from latest MLflow run.
+
+    Requires analyst role."""
     client = MLflowClientWrapper()
     try:
         _model, run_id, _model_uri = client.load_latest_model()
@@ -29,6 +33,9 @@ def get_predict_schema(role: str = Depends(require_role("analyst"))):
 def post_predict(
     req: Request, payload: PredictRequest, role: str = Depends(require_role("analyst"))
 ):
+    """Generate model prediction for provided features with validation against schema.
+
+    Requires analyst role. Enforces exact feature match to training set."""
     start = time.perf_counter()
 
     if not isinstance(payload.features, dict) or not payload.features:

--- a/app/routers/query.py
+++ b/app/routers/query.py
@@ -1,3 +1,5 @@
+"""Query endpoints: QA with optional grounding, router-based intent dispatch, memory integration."""
+
 import os
 import time
 from typing import List, Optional
@@ -68,6 +70,10 @@ class QueryResponse(BaseModel):
 
 @router.post("/query", response_model=QueryResponse)
 def post_query(req: Request, payload: QueryRequest):
+    """Answer questions with optional grounding, PII detection, or risk scoring via router.
+
+    Integrates short/long memory when enabled. Router dispatches intent dynamically.
+    Audit includes LLM usage, memory ops, and compliance flags."""
     start = time.perf_counter()
 
     # Denylist (Phase 1: env-based)

--- a/app/routers/research.py
+++ b/app/routers/research.py
@@ -1,3 +1,5 @@
+"""Research endpoints: multi-step agent loop (search, fetch, summarize, risk_check)."""
+
 import os
 import time
 from typing import List
@@ -16,6 +18,10 @@ router = APIRouter()
 
 @router.post("/research", response_model=ResearchResponse)
 def post_research(req: Request, payload: ResearchRequest):
+    """Run multi-step research agent with guest/analyst/admin role-based restrictions.
+
+    Steps: search, fetch, summarize, risk_check. Guests cannot use fetch step.
+    Audit includes step hashes and overall latency."""
     start = time.perf_counter()
 
     if not payload.topic or len(payload.topic.strip()) < 3:

--- a/app/routers/risk.py
+++ b/app/routers/risk.py
@@ -1,3 +1,5 @@
+"""Risk scoring endpoints: heuristic risk assessment of text."""
+
 import os
 import time
 
@@ -25,6 +27,9 @@ class RiskResponse(BaseModel):
 
 @router.post("/risk", response_model=RiskResponse)
 def post_risk(req: Request, payload: RiskRequest):
+    """Score text for risk (low/medium/high) with rationale and scoring method.
+
+    Requires analyst role."""
     # RBAC: analyst/admin
     role = parse_role(req)
     if role not in ("analyst", "admin"):

--- a/app/routers/think.py
+++ b/app/routers/think.py
@@ -1,3 +1,5 @@
+"""Think endpoints: extended reasoning with tool loop for complex planning."""
+
 import os
 import time
 from typing import Any, Dict, Optional
@@ -17,6 +19,9 @@ def _now_iso() -> str:
 
 @router.post("/think")
 async def think_endpoint(req: Request, payload: Dict[str, Any]):
+    """Handle extended reasoning request (ThinkRequest or ToolResult) with tool loop.
+
+    Requires analyst role. Validates request_type field."""
     role = parse_role(req)
     if role not in ("analyst", "admin"):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -1,3 +1,5 @@
+"""UI endpoints: HTML forms for architect, query, and research endpoints."""
+
 from typing import List, Optional
 import os
 
@@ -21,6 +23,7 @@ def _api_url() -> str:
 
 @router.get("/ui", response_class=HTMLResponse, tags=["UI"])
 def get_ui(request: Request):
+    """Serve tabbed UI form (architect/query/research); default tab from query param."""
     # Read optional tab query param
     tab = request.query_params.get("tab") or "architect"
     if tab not in ("architect", "query", "research"):
@@ -45,6 +48,7 @@ def ui_architect(
     grounded: Optional[str] = Form(None),
     role: Optional[str] = Form(None),
 ):
+    """Form handler: POST question to /architect and render UI with response."""
     payload = {"question": question, "mode": mode}
     headers = {"Content-Type": "application/json"}
     if role:
@@ -73,6 +77,7 @@ def ui_query(
     grounded: Optional[str] = Form(None),
     role: Optional[str] = Form(None),
 ):
+    """Form handler: POST question to /query and render UI with response."""
     payload = {"question": question, "grounded": grounded == "on"}
     headers = {"Content-Type": "application/json"}
     if role:
@@ -99,6 +104,7 @@ def ui_research(
     steps: List[str] = Form(DEFAULT_STEPS),
     role: Optional[str] = Form(None),
 ):
+    """Form handler: POST topic and steps to /research and render UI with response."""
     payload = {"topic": topic, "steps": steps}
     headers = {"Content-Type": "application/json"}
     if role:

--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -1,3 +1,4 @@
+"""Autonomous agent: search, fetch, summarize, risk-check; audit-instrumented."""
 import os
 import time
 from typing import Any, Dict, List, Tuple
@@ -8,6 +9,7 @@ from app.utils.audit import make_hash
 
 
 class Agent:
+    """Stubbed deterministic agent with offline and live modes."""
     def __init__(self):
         self.live_mode = os.getenv("AGENT_LIVE_MODE", "false").lower() == "true"
         # Optional allowlist for safety
@@ -28,6 +30,7 @@ class Agent:
         }
 
     def search(self, topic: str) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        """Return deterministic stub search results and audit step."""
         start = time.perf_counter()
         # Stubbed deterministic search results for offline/CI
         results = [
@@ -38,6 +41,7 @@ class Agent:
         return results, step
 
     def fetch(self, urls: List[str]) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        """Fetch content from URLs (live mode) or return stubs; respect AGENT_URL_ALLOWLIST."""
         start = time.perf_counter()
         contents: List[Dict[str, Any]] = []
         if self.live_mode:
@@ -64,6 +68,7 @@ class Agent:
     def summarize(
         self, docs: List[Dict[str, Any]]
     ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        """Produce stub summaries from doc texts."""
         start = time.perf_counter()
         findings = []
         for d in docs[:3]:
@@ -80,6 +85,7 @@ class Agent:
     def risk_check(
         self, topic: str, findings: List[Dict[str, Any]]
     ) -> Tuple[bool, Dict[str, Any]]:
+        """Check if content matches DENYLIST keywords; return (flagged, audit_step)."""
         start = time.perf_counter()
         denylist = [
             s.strip().lower() for s in os.getenv("DENYLIST", "").split(",") if s.strip()
@@ -96,6 +102,7 @@ class Agent:
     def run(
         self, topic: str, steps: List[str]
     ) -> Tuple[List[Dict[str, Any]], List[str], List[Dict[str, Any]], bool]:
+        """Execute named steps (search, fetch, summarize, risk_check); return (findings, sources, audit_steps, flagged)."""
         audit_steps: List[Dict[str, Any]] = []
         sources: List[str] = []
         findings: List[Dict[str, Any]] = []

--- a/app/services/architect_agent.py
+++ b/app/services/architect_agent.py
@@ -1,3 +1,4 @@
+"""Solution architect agent: memory orchestration, feature heuristics, builtin + LangGraph backends."""
 import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Tuple
@@ -23,6 +24,7 @@ except Exception:
 
 
 def _build_messages(question: str, plan_parser: PydanticOutputParser, context_blocks: List[str] | None = None) -> List[Dict[str, str]]:
+    """Construct system + context + user messages for LLM with structured output instructions."""
     context_blocks = context_blocks or []
     fmt = plan_parser.get_format_instructions()
     system = (
@@ -44,6 +46,7 @@ def _build_messages(question: str, plan_parser: PydanticOutputParser, context_bl
 
 
 def _memory_debug(e: Exception) -> None:
+    """Print memory operation errors if MEMORY_DEBUG is set."""
     if os.getenv("MEMORY_DEBUG", "").lower() in ("1", "true", "yes", "on"):
         try:
             print(f"[MEMORY_DEBUG] memory op error: {e}")
@@ -184,6 +187,10 @@ def _apply_feature_heuristic(plan: ArchitectPlan, question: str) -> None:
 
 
 def run_architect_agent(question: str, session_id: str | None = None, user_id: str | None = None, llm_model: str | None = None) -> Tuple[ArchitectPlan, Dict[str, Any]]:
+    """Orchestrate memory load/save and run planner (LangGraph or builtin with fallback).
+
+    Applies feature heuristic and audit counters; returns plan + metadata.
+    """
     """Backend-agnostic entrypoint: memory load/save and the feature-request
     heuristic live here so every backend gets them; only planning is
     backend-specific (AGENT_BACKEND=builtin|langgraph, builtin the default
@@ -231,6 +238,7 @@ def _run_builtin_planner(
     llm_model: str | None,
     read_counters: Dict[str, int],
 ) -> Tuple[ArchitectPlan, Dict[str, Any]]:
+    """Linear pipeline: RAG retrieval, message build, LLM call, structured parsing, audit assembly."""
     original_question = question
 
     # 1) Retrieval

--- a/app/services/architect_schema.py
+++ b/app/services/architect_schema.py
@@ -1,9 +1,11 @@
+"""Structured output schema for architecture planning."""
 from typing import Any, Dict, List
 
 from pydantic import BaseModel, Field
 
 
 class ArchitectPlan(BaseModel):
+    """Solution plan with summary, steps, env flags, citations, and feature request hints."""
     summary: str = ""
     suggested_steps: List[str] = Field(default_factory=list)
     suggested_env_flags: List[str] = Field(default_factory=list)

--- a/app/services/langgraph_architect.py
+++ b/app/services/langgraph_architect.py
@@ -146,6 +146,7 @@ def _route(state: AgentState) -> str:
 
 
 def build_graph(llm: LLMClient, llm_model: Optional[str] = None):
+    """Assemble LangGraph state machine: agent + tools nodes with conditional routing."""
     graph = StateGraph(AgentState)
     graph.add_node("agent", _make_agent_node(llm, llm_model))
     graph.add_node("tools", _tools_node)
@@ -162,6 +163,7 @@ def run_langgraph_architect(
     llm_model: str | None = None,
     context_blocks: List[str] | None = None,
 ) -> Tuple[ArchitectPlan, Dict[str, Any]]:
+    """Run agent loop with document retrieval tool; return plan + audit with tool-call counts."""
     llm = LLMClient()
     app = build_graph(llm, llm_model)
     # Memory context (loaded by run_architect_agent) rides in as a system

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -1,3 +1,4 @@
+"""LLM client: LiteLLM-backed with offline stub fallback, audit metadata included."""
 import os
 from typing import Any, Dict, List, Optional
 
@@ -11,6 +12,7 @@ from app.utils.logger import get_logger
 
 
 class LLMClient:
+    """LiteLLM wrapper with configurable provider/model and offline fallback."""
     def __init__(self):
         self.provider = (os.getenv("LLM_PROVIDER", "stub") or "stub").lower()
         self.model = os.getenv("LLM_MODEL", "gpt-4o-mini")
@@ -70,6 +72,7 @@ class LLMClient:
     def call(
         self, messages: List[Dict[str, str]], model: Optional[str] = None, **kwargs
     ) -> Dict[str, Any]:
+        """Call LLM via LiteLLM; return (text, provider, model, tokens, cost_usd) or stub on failure."""
         provider = self.provider
         model_to_use = model or self.model
         if provider == "stub":

--- a/app/services/mlflow_client.py
+++ b/app/services/mlflow_client.py
@@ -1,3 +1,4 @@
+"""MLflow client: load models + signatures from runs, with optional caching."""
 import os
 import json
 from typing import List, Optional
@@ -12,6 +13,8 @@ os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
 
 
 class MLflowClientWrapper:
+    """MLflow client for model loading and metadata extraction from runs."""
+
     def __init__(self, tracking_uri: str | None = None, experiment: str | None = None):
         self.tracking_uri = tracking_uri or os.getenv(
             "MLFLOW_TRACKING_URI", "./.mlruns"
@@ -64,6 +67,7 @@ class MLflowClientWrapper:
         return model
 
     def load_latest_model(self, artifact_path: str | None = None):
+        """Load model from explicit MLFLOW_MODEL_URI or latest run; return (model, run_id, uri)."""
         # Prefer explicit model URI override if provided
         explicit_uri = os.getenv("MLFLOW_MODEL_URI")
         if explicit_uri:
@@ -85,6 +89,7 @@ class MLflowClientWrapper:
         return model, run_id, uri
 
     def get_signature_input_names(self, model_uri: str) -> Optional[List[str]]:
+        """Extract model signature input column names; return None if unavailable."""
         try:
             from mlflow.models import get_model_info
 
@@ -104,7 +109,7 @@ class MLflowClientWrapper:
         return None
 
     def get_feature_order(self, run_id: Optional[str] = None) -> Optional[List[str]]:
-        """Try to download feature_order.json from the given run and return the list."""
+        """Download and parse feature_order.json from run artifact; return None if unavailable."""
         try:
             rid = run_id or self._get_latest_run_id()
             artifact_uri = f"runs:/{rid}/{self.feature_order_artifact}"
@@ -122,4 +127,5 @@ class MLflowClientWrapper:
         return None
 
     def get_experiment_name(self) -> str:
+        """Return configured experiment name."""
         return self.experiment

--- a/app/services/pii_detector.py
+++ b/app/services/pii_detector.py
@@ -1,3 +1,4 @@
+"""Simple, deterministic PII detector: regex + optional Presidio backend."""
 import os
 import re
 from typing import Any, Dict, List
@@ -108,6 +109,10 @@ def _compile_active_patterns(types_override: list[str] | None = None, locales_ov
 
 
 def detect_pii(text: str, types: list[str] | None = None, locales: list[str] | None = None) -> Dict[str, Any]:
+    """Detect PII in text using Presidio (if PII_BACKEND=presidio) or regex baseline.
+
+    Returns entities (type, masked value, span), type counts, and detected types.
+    """
     # Optional Presidio backend (PII_BACKEND=presidio); the regex baseline
     # below stays the default and the fallback when Presidio is not
     # installed or fails (e.g. missing spaCy model).

--- a/app/services/pii_remediation.py
+++ b/app/services/pii_remediation.py
@@ -1,3 +1,4 @@
+"""PII remediation synthesis: per-type policies and optional doc-grounded guidance."""
 import os
 from typing import Any, Dict, List
 
@@ -52,6 +53,7 @@ def _retrieve_guidance(query: str, k: int = 2) -> List[Dict[str, Any]]:
 def synthesize_remediation(
     entities: List[Dict[str, Any]], include_snippets: bool, grounded: bool
 ) -> Dict[str, Any]:
+    """Build per-type remediation policies; optionally retrieve doc-grounded guidance."""
     remediations = _default_remediations()
     per_type: Dict[str, Dict[str, Any]] = {}
     citations: List[Dict[str, Any]] = []

--- a/app/services/policy_navigator.py
+++ b/app/services/policy_navigator.py
@@ -1,3 +1,4 @@
+"""Policy navigator: decompose, retrieve, synthesize compliance guidance."""
 import os
 from typing import Any, Dict, List
 
@@ -7,6 +8,7 @@ logger = get_logger(__name__)
 
 
 def decompose(question: str, max_subqs: int | None = None) -> List[str]:
+    """Split question into sub-questions by punctuation; filter short segments."""
     q = question.strip()
     parts = []
     # naive decomposition: split by '?' and '.'; filter short parts
@@ -22,6 +24,7 @@ def decompose(question: str, max_subqs: int | None = None) -> List[str]:
 
 
 def retrieve(subq: str, k: int = 3) -> List[Dict[str, Any]]:
+    """Fetch top-k citations for sub-question using doc retriever."""
     # Use the keyword-scan retriever
     try:
         from app.services.doc_retriever import answer_with_citations
@@ -35,6 +38,7 @@ def retrieve(subq: str, k: int = 3) -> List[Dict[str, Any]]:
 def synthesize(
     question: str, subqs: List[str], per_subq_citations: List[List[Dict[str, Any]]]
 ) -> Dict[str, Any]:
+    """Assemble structured guidance from sub-questions and their citations."""
     # naive synthesis: summarize findings and provide a recommendation
     lines = [f"Policy navigator for: {question}"]
     all_citations: List[Dict[str, Any]] = []

--- a/app/services/risk_scorer.py
+++ b/app/services/risk_scorer.py
@@ -1,3 +1,4 @@
+"""Risk scoring: keyword-based heuristics and optional deterministic ML."""
 import os
 from typing import Dict, Tuple
 
@@ -43,6 +44,7 @@ def _env_truthy(name: str, default: str = "false") -> bool:
 
 
 def heuristic_score(text: str) -> Dict[str, object]:
+    """Score text by keyword membership in risk tiers; return (label, value, rationale, method)."""
     t = (text or "").lower()
     score = 0.0
     label = "low"
@@ -93,6 +95,7 @@ def _deterministic_ml_score(text: str, threshold: float) -> Tuple[str, float, st
 
 
 def score(text: str) -> Dict[str, object]:
+    """Score text using ML (if RISK_ML_ENABLED) or heuristic method."""
     # If ML enabled, compute deterministic pseudo-ML score; else heuristic
     ml_enabled = _env_truthy("RISK_ML_ENABLED", "false")
     try:

--- a/app/services/router.py
+++ b/app/services/router.py
@@ -1,3 +1,4 @@
+"""Intent router: keyword rules + builtin heuristics to classify user queries."""
 import json
 import os
 from typing import Any, Dict, List, Literal
@@ -125,6 +126,10 @@ def _route_builtin(question: str, grounded: bool) -> Intent:
 
 
 def route_intent(question: str, grounded: bool) -> Intent:
+    """Classify question as QA, PII detection, risk scoring, policy navigation, or remediation.
+
+    Uses ROUTER_BACKEND (rules or builtin); grounded queries always map to QA.
+    """
     backend = os.getenv("ROUTER_BACKEND", _BACKEND_NAME).lower()
     try:
         if backend == "rules":
@@ -144,4 +149,5 @@ def route_intent(question: str, grounded: bool) -> Intent:
 
 
 def get_backend_meta() -> str:
+    """Return router backend name and version."""
     return f"{_BACKEND_NAME}_{_BACKEND_VERSION}"

--- a/app/services/think_planner.py
+++ b/app/services/think_planner.py
@@ -1,3 +1,4 @@
+"""Router for think/tool-result requests: adapts payload to architect agent."""
 import os
 from typing import Any, Dict, Tuple
 

--- a/app/services/vector_retriever.py
+++ b/app/services/vector_retriever.py
@@ -40,6 +40,7 @@ class HashEmbeddings:
     """
 
     def embed(self, texts: List[str]) -> List[List[float]]:
+        """Hash texts to normalized vectors over fixed buckets."""
         out: List[List[float]] = []
         for text in texts:
             vec = [0.0] * HASH_DIM
@@ -54,6 +55,7 @@ class HashEmbeddings:
 
 
 def get_embedder():
+    """Return configured embeddings provider (hash, stub, or local sentence-transformers)."""
     provider = os.getenv("EMBEDDINGS_PROVIDER", "local").lower()
     if provider == "hash":
         return HashEmbeddings()
@@ -67,6 +69,7 @@ def get_embedder():
 
 
 def get_collection(create: bool = False):
+    """Return Chroma collection; create if missing and create=True."""
     import chromadb
 
     client = chromadb.PersistentClient(path=vectorstore_path())
@@ -86,7 +89,7 @@ def is_ready() -> bool:
 
 
 def query(question: str, k: int = 3) -> List[Dict[str, Any]]:
-    """Return top-k chunk citations for the question.
+    """Return top-k chunk citations for the question, filtered by RAG_EXCLUDE_FILES.
 
     Raises on any backend failure; the caller decides whether to fall back.
     """

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -135,3 +135,36 @@ See `docs/eval_results/2026-07-04-grid-backend-tokens.md`.
 
 - ports_and_adapters.md: interface-first architecture and planner/RAG backends
 - related_projects.md: curated ecosystem overview and how this project complements it
+
+## Design (architect)
+
+**Owns:** turning a question into a validated `ArchitectPlan` plus an audit dict.
+`run_architect_agent` in `app/services/architect_agent.py` is the only entry point
+routers and the MCP server call; backend choice is an implementation detail behind it.
+
+**Contract:** `run_architect_agent(question, session_id?, user_id?, llm_model?) ->
+(ArchitectPlan, audit)`. The plan always has non-null `summary` and
+`suggested_steps`; `grounded_used` is true iff citations are attached. The audit
+always carries `agent_backend`, token/cost fields, and the full set of memory_*
+counters regardless of backend.
+
+**Invariants:**
+- Cross-cutting behavior lives in the wrapper, not in backends: memory load/save
+  and the feature-CTA heuristic run around whichever backend executes. A new
+  backend gets them for free and cannot silently drop them (regression-tested in
+  tests/test_backend_parity.py; this invariant was extracted from a real incident
+  where the langgraph switch lost both).
+- The builtin planner is the universal fallback: any langgraph exception, and any
+  langgraph run that finalizes with an empty summary, falls back to builtin rather
+  than surfacing a failure or an empty plan.
+- The langgraph tool loop is budgeted (3 retrieve_docs calls); at the cap the model
+  is told to finalize from existing context.
+- Offline-safe by default: `AGENT_BACKEND=builtin` + stub LLM is deterministic and
+  network-free, which is what the test suite and CI run.
+
+**Why two backends:** builtin gives determinism (tests, CI, fallback); langgraph
+gives quality (measured winner on groundedness and latency). Keeping the seam at
+`run_architect_agent` lets eval experiments swap backends with one env var.
+
+**Non-goals:** the wrapper does not stream (the SSE endpoint wraps it), does not
+choose models (LLMClient + env), and does not know about HTTP.

--- a/docs/architecture_index.md
+++ b/docs/architecture_index.md
@@ -2,48 +2,69 @@
 title: Architecture index
 status: current
 module: architecture
-last_reviewed: 2026-07-04
+last_reviewed: 2026-07-05
+source:
+  - app/main.py
 ---
 
 # Architecture index
 
-This document orients the Architect use case by linking core components, endpoints, env flags, and flows.
+The system map: how a request flows through the subsystems, and where each
+subsystem's deep description lives. Each linked doc ends with a **Design** section
+covering what the module owns, its contract, invariants, and non-goals.
 
-## Core endpoints and roles
+## Life of an /architect request
 
-- /query: RAG QA, optional router intents
-- /pii: PII detection and remediation helpers
-- /risk: Heuristic risk scoring (ML mode paused)
-- /research: Research agent with safety and denylist controls
-- /memory/short and /memory/long: conversational memory stores
-- /metrics, /healthz: observability and health
+1. **Gateway** (`app/main.py`): middleware attaches a request id and metrics timers;
+   RBAC parses `X-User-Role`.
+2. **Wrapper** (`run_architect_agent`, [agents.md](agents.md)): loads short-term
+   turns and long-term facts ([memory.md](memory.md)), then dispatches by
+   `AGENT_BACKEND`.
+3. **Backend**: builtin (deterministic planner: retrieval, one structured LLM call)
+   or langgraph (tool loop that may call `retrieve_docs` up to 3 times). Both
+   ground through the retrieval facade ([rag.md](rag.md)); both call the LLM through
+   LLMClient (LiteLLM routing, real cost tracking).
+4. **Wrapper again**: applies the feature-CTA heuristic, saves the turn to memory,
+   merges memory counters into the audit.
+5. **Delivery**: `/architect` returns JSON; `/architect/stream` emits SSE
+   (status, then meta/summary/steps/flags/citations, optional feature, final audit;
+   error on failure). Contract in [agents.md](agents.md).
+6. **Governance**: an audit row is written best-effort ([audit.md](audit.md));
+   metrics land in Prometheus ([observability_metrics.md](observability_metrics.md));
+   a LangSmith run tree is posted when tracing is enabled
+   ([observability.md](observability.md)).
 
-## Router concepts
+## Life of a /query request
 
-- Enable with ROUTER_ENABLED=true
-- Configure with ROUTER_RULES_JSON or ROUTER_RULES_PATH; backend is rules v2
-- Intents: qa, pii_detect, risk_score, policy_navigator, pii_remediation, other
+The router selects the intent ([router.md](router.md)): qa goes through the same
+retrieval facade (grounded) or optional LLM synthesis; pii/risk/policy intents
+dispatch to their services ([pii.md](pii.md); full endpoint list in
+[capabilities_current.md](capabilities_current.md)). Memory and audit behave as
+above.
 
-## RAG flags
+## Subsystem map
 
-- RAG_MULTI_QUERY_ENABLED, RAG_MULTI_QUERY_COUNT
-- RAG_HYDE_ENABLED
-- DOCS_PATH to select corpus
+| Subsystem | Doc (with Design section) | Code |
+|---|---|---|
+| Architect agent (both backends) | [agents.md](agents.md) | app/services/architect_agent.py, app/services/langgraph_architect.py |
+| Retrieval / RAG | [rag.md](rag.md) | app/services/doc_retriever.py, app/services/vector_retriever.py |
+| Memory (short + long) | [memory.md](memory.md) | app/memory/ |
+| Router (intents) | [router.md](router.md) | app/services/router.py |
+| Audit | [audit.md](audit.md) | app/utils/audit.py, db/ |
+| Metrics / tracing | [observability.md](observability.md), [observability_metrics.md](observability_metrics.md) | app/utils/metrics.py |
+| Evaluation | [langsmith_test_plan.md](langsmith_test_plan.md), eval_results/ | scripts/ |
 
-## Memory model
+## Cross-cutting rules
 
-- Short memory: capped + pruning semantics; clear endpoints
-- Long memory: retention and list/clear endpoints
-- RBAC enforced for memory operations
-
-## Observability
-
-- Prometheus /metrics (optionally protected by METRICS_TOKEN)
-- OpenAPI export script and Grafana dashboards
+- Cross-cutting agent behavior (memory, feature CTA) lives in the wrapper, never in
+  a backend ([agents.md](agents.md) Design).
+- docs/ is the RAG corpus; docs/worklog/ is excluded ([rag.md](rag.md) Design).
+- Offline determinism is the CI default: stub LLM + keyword_scan + builtin backend.
+- Every endpoint audits best-effort; auditing never fails a request.
 
 ## Use case mapping checklist
 
 - Define intent (QA vs PII vs Risk vs Research)
 - Choose grounded=true when you need citations
-- Identify env flags to enable features
-- Outline endpoints and services to modify
+- Identify env flags to enable features ([config.md](config.md))
+- Outline endpoints and services to modify ([components.md](components.md))

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -28,3 +28,30 @@ source:
 - Script: scripts/sweep_retention.py
 - Usage: python scripts/sweep_retention.py
 - Recommended to run periodically (cron/k8s job) depending on policy.
+
+## Design
+
+**Owns:** the append-only record of what the system did per request.
+`write_audit(db, **fields)` in `app/utils/audit.py` plus the `Audit` model in
+`db/models.py`; `make_hash` provides sha256 content hashes so prompts/responses are
+attributable without storing raw text in fixed columns.
+
+**Contract:** one audit row per handled request, written best-effort at the end of
+the handler. Fixed columns (request_id, endpoint, user_id, created_at, tokens,
+cost_usd, latency_ms, compliance_flag, prompt_hash, response_hash) plus
+feature-specific extras in the response audit payload.
+
+**Invariants:**
+- Auditing never breaks the API: a failed write is logged, rolled back, and the
+  response still returns. The audit is an observability guarantee, not a
+  transactional one; consumers must not assume 100% coverage under DB failure.
+- Rows are append-only in practice: nothing in the app updates or deletes audit
+  rows except the retention sweep script.
+- Hashes, not payloads, in fixed columns: content is referenced by sha256 so the
+  table stays lean and privacy exposure is bounded.
+
+**Why it exists:** the governance story (who did what, at what cost, with which
+backend/model/policy inputs) is a first-class product feature, not debug logging.
+
+**Non-goals:** not a metrics system (Prometheus owns aggregates), not tamper-evident
+(no signing/chaining), not a transaction log for replay.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -91,3 +91,31 @@ This service supports short-term conversation memory and long-term semantic memo
 
 - SHORT_MEMORY_RETENTION_DAYS=7; SHORT_MEMORY_MAX_TURNS_PER_SESSION=100
 - MEMORY_LONG_RETENTION_DAYS=180; MEMORY_LONG_MAX_FACTS=500
+
+## Design
+
+**Owns:** conversational continuity. Two tiers with different lifetimes and shapes:
+short-term (verbatim turns per user+session, SQLite) and long-term (distilled facts
+per user, in-process semantic store). `app/memory/short_memory.py` and
+`app/memory/long_memory.py` own their stores; nothing else writes to them.
+
+**Contract (short):** `load_turns(user_id, session_id) -> [(role, content)]`,
+`save_turn(...)`, `load_summary(...)`; pruning (retention days, per-session cap)
+happens on read and is reported via `_last_pruned`. **Contract (long):**
+`retrieve_facts(user_id, question, top_k)`, `ingest_fact(user_id, text)`.
+
+**Invariants:**
+- Keying is always (user_id, session_id) for turns, user_id for facts; an absent
+  session_id maps to "default", so callers that want isolation must pass one
+  (the eval harnesses generate a fresh session id per example for this reason).
+- Memory never fails a request: all memory operations are best-effort with
+  exceptions swallowed (set MEMORY_DEBUG=true to surface them).
+- Consumers integrate through `run_architect_agent` / the query router, which load
+  context before the LLM call and save after; backends never call memory directly
+  (this is what keeps memory backend-agnostic across builtin and langgraph).
+
+**Why it exists:** multi-turn coherence for the architect UI and /query without
+coupling memory shape to any particular agent implementation.
+
+**Non-goals:** cross-user recall, vector-DB-backed long memory (in-process by
+design at this scale), automatic summarization beyond the rolling window.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6,6 +6,7 @@ paths:
   /healthz:
     get:
       summary: Healthz
+      description: 'Liveness check: returns ok when the process is up.'
       operationId: healthz_healthz_get
       responses:
         '200':
@@ -16,6 +17,8 @@ paths:
   /metrics:
     get:
       summary: Metrics
+      description: Prometheus metrics export (text/plain). Token required if METRICS_TOKEN
+        env set.
       operationId: metrics_metrics_get
       parameters:
       - name: X-Metrics-Token
@@ -42,6 +45,13 @@ paths:
   /query:
     post:
       summary: Post Query
+      description: 'Answer questions with optional grounding, PII detection, or risk
+        scoring via router.
+
+
+        Integrates short/long memory when enabled. Router dispatches intent dynamically.
+
+        Audit includes LLM usage, memory ops, and compliance flags.'
       operationId: post_query_query_post
       requestBody:
         content:
@@ -65,6 +75,13 @@ paths:
   /research:
     post:
       summary: Post Research
+      description: 'Run multi-step research agent with guest/analyst/admin role-based
+        restrictions.
+
+
+        Steps: search, fetch, summarize, risk_check. Guests cannot use fetch step.
+
+        Audit includes step hashes and overall latency.'
       operationId: post_research_research_post
       requestBody:
         content:
@@ -88,7 +105,11 @@ paths:
   /predict/schema:
     get:
       summary: Get Predict Schema
-      description: Return expected feature list and model metadata from latest run.
+      description: 'Retrieve expected feature order and model metadata from latest
+        MLflow run.
+
+
+        Requires analyst role.'
       operationId: get_predict_schema_predict_schema_get
       responses:
         '200':
@@ -102,6 +123,11 @@ paths:
   /predict:
     post:
       summary: Post Predict
+      description: 'Generate model prediction for provided features with validation
+        against schema.
+
+
+        Requires analyst role. Enforces exact feature match to training set.'
       operationId: post_predict_predict_post
       requestBody:
         content:
@@ -125,6 +151,10 @@ paths:
   /pii:
     post:
       summary: Post Pii
+      description: 'Detect PII types in text and return counts by entity type.
+
+
+        Requires analyst role. Optional grounded citations from policy docs.'
       operationId: post_pii_pii_post
       requestBody:
         content:
@@ -148,6 +178,11 @@ paths:
   /risk:
     post:
       summary: Post Risk
+      description: 'Score text for risk (low/medium/high) with rationale and scoring
+        method.
+
+
+        Requires analyst role.'
       operationId: post_risk_risk_post
       requestBody:
         content:
@@ -171,6 +206,10 @@ paths:
   /memory/short:
     get:
       summary: Get Short Memory
+      description: 'Retrieve conversation turns and summary for user/session.
+
+
+        Requires analyst role. Returns empty on disabled flag. Includes pruned count.'
       operationId: get_short_memory_memory_short_get
       parameters:
       - name: user_id
@@ -200,6 +239,10 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
     delete:
       summary: Delete Short Memory
+      description: 'Clear turns and summary for user/session.
+
+
+        Requires analyst role. Idempotent: returns cleared=true when enabled.'
       operationId: delete_short_memory_memory_short_delete
       parameters:
       - name: user_id
@@ -232,6 +275,10 @@ paths:
   /memory/long:
     get:
       summary: Get Long Memory
+      description: 'Retrieve facts for user, optionally filtered by query.
+
+
+        Requires analyst role. Returns empty on disabled flag.'
       operationId: get_long_memory_memory_long_get
       parameters:
       - name: user_id
@@ -263,6 +310,10 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
     delete:
       summary: Delete Long Memory
+      description: 'Clear all facts for user.
+
+
+        Requires analyst role. Idempotent: returns cleared=true when enabled.'
       operationId: delete_long_memory_memory_long_delete
       parameters:
       - name: user_id
@@ -289,6 +340,10 @@ paths:
   /memory/status:
     get:
       summary: Get Memory Status
+      description: 'Inspect memory config, database health, and pruning counters.
+
+
+        Requires admin role.'
       operationId: get_memory_status_memory_status_get
       responses:
         '200':
@@ -302,6 +357,10 @@ paths:
   /memory/long/export:
     get:
       summary: Export Long Memory
+      description: 'Export all facts for user with retention pruning applied.
+
+
+        Requires analyst role. Includes embedding presence metadata.'
       operationId: export_long_memory_memory_long_export_get
       parameters:
       - name: user_id
@@ -326,6 +385,10 @@ paths:
   /memory/long/import:
     post:
       summary: Import Long Memory
+      description: 'Ingest facts for user with automatic eviction on size limits.
+
+
+        Requires analyst role. Tracks evictions triggered during import.'
       operationId: import_long_memory_memory_long_import_post
       parameters:
       - name: user_id
@@ -358,6 +421,12 @@ paths:
   /policy_navigator:
     post:
       summary: Post Policy Navigator
+      description: 'Answer policy questions via decompose-retrieve-synthesize loop.
+
+
+        Requires analyst role. Gated by POLICY_NAV_ENABLED flag (default true).
+
+        Audit includes step-by-step latencies and hashes.'
       operationId: post_policy_navigator_policy_navigator_post
       requestBody:
         content:
@@ -381,6 +450,11 @@ paths:
   /pii_remediation:
     post:
       summary: Post Pii Remediation
+      description: 'Synthesize remediation steps for detected PII with optional code
+        snippets.
+
+
+        Requires analyst role. Gated by PII_REMEDIATION_ENABLED flag (default true).'
       operationId: post_pii_remediation_pii_remediation_post
       requestBody:
         content:
@@ -406,6 +480,13 @@ paths:
       tags:
       - Architect
       summary: Post Architect
+      description: 'Generate structured plan from question with optional grounded
+        retrieval.
+
+
+        Requires PROJECT_GUIDE_ENABLED flag. Optional LLM synthesis when LLM_ENABLE_ARCHITECT=true.
+
+        Audit includes prompt/response hashes and LLM usage when agent runs.'
       operationId: post_architect_architect_post
       requestBody:
         content:
@@ -429,6 +510,14 @@ paths:
   /architect/stream:
     get:
       summary: Stream Architect
+      description: 'Stream the architect plan as SSE events: status first (immediate
+        ack),
+
+        then meta, summary, steps, flags, citations, optional feature, final audit;
+
+        a server-side failure emits an error event. Questions under 3 characters get
+
+        an empty stream (single bare meta event), not an HTTP error.'
       operationId: stream_architect_architect_stream_get
       parameters:
       - name: question
@@ -481,6 +570,7 @@ paths:
       tags:
       - Architect
       summary: Get Ui
+      description: Serve architect form HTML, gated by PROJECT_GUIDE_ENABLED flag.
       operationId: get_ui_architect_ui_get
       responses:
         '200':
@@ -494,6 +584,8 @@ paths:
       tags:
       - UI
       summary: Get Ui
+      description: Serve tabbed UI form (architect/query/research); default tab from
+        query param.
       operationId: get_ui_ui_get
       responses:
         '200':
@@ -507,6 +599,7 @@ paths:
       tags:
       - UI
       summary: Ui Architect
+      description: 'Form handler: POST question to /architect and render UI with response.'
       operationId: ui_architect_ui_architect_post
       requestBody:
         content:
@@ -532,6 +625,7 @@ paths:
       tags:
       - UI
       summary: Ui Query
+      description: 'Form handler: POST question to /query and render UI with response.'
       operationId: ui_query_ui_query_post
       requestBody:
         content:
@@ -557,6 +651,8 @@ paths:
       tags:
       - UI
       summary: Ui Research
+      description: 'Form handler: POST topic and steps to /research and render UI
+        with response.'
       operationId: ui_research_ui_research_post
       requestBody:
         content:
@@ -580,6 +676,11 @@ paths:
   /think:
     post:
       summary: Think Endpoint
+      description: 'Handle extended reasoning request (ThinkRequest or ToolResult)
+        with tool loop.
+
+
+        Requires analyst role. Validates request_type field.'
       operationId: think_endpoint_think_post
       requestBody:
         content:

--- a/docs/rag.md
+++ b/docs/rag.md
@@ -85,3 +85,35 @@ contracts. Keep new tests offline; never depend on a model download.
 - `rag_vector_backends.md`: backend matrix and planned managed backends
 - `ports_and_adapters.md`: RAGPort design and how backends plug in
 - `docs/adr/0005-doc-retriever-naming.md`: why the module was renamed
+
+## Design
+
+**Owns:** everything between a question and grounding context: backend selection,
+corpus exclusion, query expansion, and citation shaping. Nothing else in the app
+touches the corpus directly; `answer_with_citations()` in
+`app/services/doc_retriever.py` is the single entry point (the facade), used by
+/query, both architect backends, and the MCP server.
+
+**Contract:** `answer_with_citations(question, k) -> {answer, citations[],
+rag_multi_query?, rag_multi_count?, rag_hyde?}`. Citations carry `source`, optional
+`page`, `snippet`, `distance`. Callers may treat an empty citations list as
+"ungrounded"; they never receive excluded content.
+
+**Invariants:**
+- Exclusion is enforced at all three paths (keyword scan, vector query, ingestion),
+  so a stale store cannot leak excluded files: the vector path over-fetches 2x and
+  drops excluded chunks post-hoc.
+- The vector backend falls back to keyword scan when the store is missing or empty;
+  callers never see a hard failure from a missing store.
+- Ingestion is add/update only. Deleting or renaming a doc requires wiping
+  `VECTORSTORE_PATH` and re-ingesting, or its chunks stay retrievable.
+- Determinism: with `RAG_BACKEND=keyword_scan` (the default) retrieval is fully
+  deterministic, which is what CI and the offline test suite rely on.
+
+**Why it exists:** grounding quality is the product's main quality lever (measured:
+the 2026-07-04 corpus cleanup moved judge groundedness more than any backend
+change), so retrieval is centralized where exclusion and fallback rules can be
+enforced once and measured.
+
+**Non-goals:** no reranking, no hybrid search, no managed vector DBs (roadmap);
+no write access for callers.

--- a/docs/router.md
+++ b/docs/router.md
@@ -46,3 +46,30 @@ The Router selects an intent for /query: qa, pii_detect, risk_score, policy_navi
 - Expected: audit.router_intent == "pii_detect"
 
 See docs/router_rules.md for the rules schema and more examples.
+
+## Design
+
+**Owns:** intent selection for /query: mapping a question (plus groundedness) to one
+of the canonical intents. `route_intent(question, grounded)` in
+`app/services/router.py` is the whole public surface.
+
+**Contract:** returns exactly one intent string (qa, pii_detect, risk_score,
+policy_navigator, pii_remediation, other); never raises; the audit records
+`router_backend` (rules | builtin | simple) and `router_intent`.
+
+**Invariants:**
+- Resolution order: configured rules (highest priority wins) first; when rules
+  yield the default intent but the builtin heuristics find a stronger one (e.g.
+  pii), the builtin result wins. No rules configured = builtin heuristics.
+- `grounded=true` always routes to qa: a user explicitly asking for citations has
+  declared their intent, so keyword heuristics must not override it.
+- Rules are loaded once and cached per process (`ROUTER_RULES_JSON` beats
+  `ROUTER_RULES_PATH`).
+
+**Why it exists:** one place to decide "what kind of request is this," so endpoint
+behavior and audit stay consistent as intents grow. It is deliberately cheap
+(keyword rules, no LLM call) because it runs on every /query.
+
+**Non-goals:** no build/collaborate intent yet (the feature-CTA heuristic in the
+architect wrapper covers that need today; folding it into the router is the planned
+path for intent-conditioned responses), no LLM-based classification.

--- a/docs/worklog/2026-07-04-docs-knowledge-backlog.md
+++ b/docs/worklog/2026-07-04-docs-knowledge-backlog.md
@@ -107,6 +107,18 @@ file is the first entry.
 - Small chore: relocate audit.db out of repo root into data/, update path config,
   gitignore if not already.
 
+### 10. Embeddings health: fail loudly on stub fallback [FOUND 2026-07-05]
+- Incident: the running server's LocalEmbeddings silently fell back to stub
+  embeddings after a reload under memory pressure. Every query then retrieved the
+  SAME three chunks regardless of question; judge correctness dropped ~0.9 before
+  the eval diff caught it. Nothing logged, nothing in audit.
+- Fix ideas: log at WARNING on fallback; expose embedder identity (local/stub/hash)
+  in the audit rag extras and /healthz or /memory/status-style endpoint; optionally
+  a startup check that refuses vector backend with stub embeddings unless
+  explicitly allowed.
+- The eval-diff discipline caught this; a single-number canary (retrieval
+  diversity: distinct sources over N queries) would catch it in seconds.
+
 ## Process (adopted this session)
 - approach.md pattern adopted (community practice): per-task
   approach doc written BEFORE implementation, approved as the gate; code review checks

--- a/docs/worklog/2026-07-05-approach-module-docs.md
+++ b/docs/worklog/2026-07-05-approach-module-docs.md
@@ -1,0 +1,50 @@
+# Approach: module docs + docstrings (backlog item 5)
+
+Status: APPROVED 2026-07-05
+Relates to: 2026-07-04-docs-knowledge-backlog.md item 5.
+
+## Goal
+
+Give the runtime agent (via the corpus) and maintainers a deep, per-subsystem
+understanding: what each module owns, its contracts, and why it exists. Docstrings
+serve code readers; module docs serve the agent.
+
+## Design decision (flagging explicitly)
+
+NOT creating a parallel docs/modules/ tree. The subsystem docs already exist (rag.md,
+agents.md, memory.md, router.md, audit.md, observability.md) and are usage/config
+focused. A parallel tree would duplicate content in the corpus, and duplication is
+retrieval noise. Instead each subsystem doc gains a **Design** section: what the module
+owns, its public contract (functions/inputs/outputs), key invariants, why it exists,
+and what it deliberately does not do. architecture_index.md becomes the map that ties
+them together.
+
+## Plan
+
+1. Design sections (judgment work, main model, one commit per subsystem):
+   - rag.md — retrieval facade contract, backend selection, exclusion invariants,
+     the never-deletes ingest property, fallback chain
+   - agents.md — run_architect_agent as the backend-agnostic wrapper (memory +
+     CTA invariants), builtin vs langgraph contracts, fallback semantics
+   - memory.md — two-tier design, session keying, pruning semantics, audit counters
+   - router.md — intent contract, rules vs builtin resolution order
+   - audit.md + observability.md — audit row contract, what is guaranteed best-effort
+   - architecture_index.md — request lifecycle walk-through linking the above
+2. Docstrings (mechanical batches, haiku agents, explicit model override):
+   - Public surfaces first: app/routers/*, app/services/*, app/memory/*, both agent
+     backends. Module-level docstring + public functions. Skip trivial helpers.
+   - Style: concise, states contract and gotchas, no narration of obvious code.
+3. CLAUDE.md pointers updated to the Design sections.
+
+## Verification
+
+- Full test suite (docstrings must not change behavior; pure additions).
+- Store rebuild + eval run, diff vs docs-overhaul-headings-0d660fad. Design sections
+  add corpus content, so this is a measurable corpus change.
+- Docstring batches spot-checked for accuracy against the code they describe
+  (wrong docstrings are worse than none).
+
+## Out of scope
+
+- Intent-flexible responses (item 6), Makefile (item 7).
+- Docstrings for tests, scripts/, ml/ (lower value; can follow later).


### PR DESCRIPTION
Backlog item 5; approach doc: docs/worklog/2026-07-05-approach-module-docs.md (approved).

## Changes

- **Design sections** appended to each subsystem doc (rag, memory, agents, router, audit): what the module owns, its public contract, invariants, why it exists, non-goals. No parallel docs/modules/ tree, so nothing is duplicated in the corpus.
- **architecture_index.md rewritten** as the system map: life-of-a-request walkthroughs for /architect and /query, a subsystem table linking every Design section, and the cross-cutting rules (wrapper-owns-cross-cutting-behavior, corpus rule, offline determinism, best-effort audit).
- **Docstrings** on app/routers/, app/services/, app/memory/: module docstrings plus contract-style docstrings (inputs/outputs, RBAC gates, env flags, fallbacks) on public functions. Insertions only, spot-checked against code (one inaccurate claim fixed, two unauthorized rewrites reverted). 181 tests pass.

## Verification and an incident worth reading

First eval run after ingesting the Design sections showed judges dropping ~0.9. Per-example diff revealed every degraded prompt had the IDENTICAL citations regardless of question: the running server's LocalEmbeddings had silently fallen back to stub embeddings after a reload under memory pressure, so every query mapped to the same neighbors. The store itself was healthy; a worker reload fixed it.

Re-run on the healthy server (`module-design-docs-v2-b3979c1f` vs `docs-overhaul-headings-0d660fad`): judges within run-to-run noise (groundedness 3.92→3.81, correctness 3.92→3.62, completeness 3.54→3.39, actionability 3.77→3.46), deterministic metrics identical, keywords_present up to 1.00, latency slightly better. The corpus change is quality-neutral by measurement; the readability/knowledge value is the point.

The silent stub fallback is now backlog item 10 (fail loudly, expose embedder identity in audit, retrieval-diversity canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)