### PR TITLE
Eval hygiene: fresh user_id per example + OpenAI embeddings as default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,11 +15,17 @@ PII_BACKEND=regex               # regex|presidio (presidio: pip install .[presid
 ROUTER_ENABLED=true
 # ROUTER_BACKEND=               # router implementation override
 # ROUTER_RULES_JSON=            # inline rules JSON (or ROUTER_RULES_PATH=path to rules file)
-EMBEDDINGS_PROVIDER=local       # local|openai|hash|stub
+# Embeddings: openai is the recommended default (network-hosted, no local
+# torch worker to swap out under memory pressure). Local sentence-transformers
+# still works but on a memory-tight host the model can silently fall back to
+# stub embeddings and collapse retrieval to identical top-k for every query.
+EMBEDDINGS_PROVIDER=openai       # local|openai|hash|stub
+OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 # LOCAL_EMBEDDING_MODEL=all-MiniLM-L6-v2
-# OPENAI_EMBEDDING_MODEL=text-embedding-ada-002
 VECTORSTORE_PATH=./.local/vectorstore
-# RAG_COLLECTION=               # Chroma collection name
+# Switching embedder (dimension change) requires wiping VECTORSTORE_PATH and
+# re-ingesting; pin a distinct collection to avoid stale-vector collisions:
+RAG_COLLECTION=docs_openai_3_small
 # NOTE: with DOCS_PATH unset, the keyword-scan query path defaults to ./examples
 # while scripts/ingest_docs.py defaults to ./docs — set it explicitly:
 DOCS_PATH=./docs

--- a/app/services/rag_retriever.py
+++ b/app/services/rag_retriever.py
@@ -45,7 +45,7 @@ class OpenAIEmbeddings:
 
     def __init__(self):
         self.api_key = os.getenv("OPENAI_API_KEY")
-        self.model = os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002")
+        self.model = os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
 
     def embed(self, texts: List[str]) -> List[List[float]]:
         """Call OpenAI embeddings API."""

--- a/docs/config.md
+++ b/docs/config.md
@@ -48,8 +48,8 @@ variable is unset; `.env.example` documents a working local setup.
 - RAG_EXCLUDE_DIRS: directory names excluded the same way (default: worklog)
 - RAG_MULTI_QUERY_ENABLED, RAG_MULTI_QUERY_COUNT, RAG_HYDE_ENABLED: query expansion
   (keyword-scan path only; no-ops under RAG_BACKEND=vector)
-- EMBEDDINGS_PROVIDER: local|openai|hash|stub
-- LOCAL_EMBEDDING_MODEL (default: all-MiniLM-L6-v2), OPENAI_EMBEDDING_MODEL (default: text-embedding-ada-002)
+- EMBEDDINGS_PROVIDER: openai|local|hash|stub (recommended: openai; see docs/rag.md for why)
+- LOCAL_EMBEDDING_MODEL (default: all-MiniLM-L6-v2), OPENAI_EMBEDDING_MODEL (default: text-embedding-3-small)
 
 ## PII / Risk
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -83,9 +83,9 @@ make test
   - LLM_PROVIDER=openai (or another LiteLLM-supported provider; `stub` = offline default)
   - LLM_MODEL=<model name, e.g. gpt-4.1-mini>
   - OPENAI_API_KEY=<your key> (provider keys are read by LiteLLM at call time)
-- Embeddings are configured separately: EMBEDDINGS_PROVIDER=local|openai|hash|stub,
-  with LOCAL_EMBEDDING_MODEL (default all-MiniLM-L6-v2) or OPENAI_EMBEDDING_MODEL
-  (default text-embedding-ada-002)
+- Embeddings are configured separately: EMBEDDINGS_PROVIDER=openai|local|hash|stub
+  (recommended: openai, see docs/rag.md), with OPENAI_EMBEDDING_MODEL
+  (default text-embedding-3-small) or LOCAL_EMBEDDING_MODEL (default all-MiniLM-L6-v2)
 - Per-request cost comes from LiteLLM's pricing map and lands in audit rows and /metrics
 
 ## Next steps

--- a/docs/rag.md
+++ b/docs/rag.md
@@ -60,11 +60,20 @@ no placeholder content is fabricated.
   the corpus)
 - `VECTORSTORE_PATH=./.local/vectorstore` — Chroma persistence dir
 - `RAG_COLLECTION=docs` — Chroma collection name
-- `EMBEDDINGS_PROVIDER=local|hash|stub` — `local` uses
-  sentence-transformers (`LOCAL_EMBEDDING_MODEL`, default all-MiniLM-L6-v2);
-  `hash` is a deterministic hashed bag-of-words used by CI golden-query
-  tests (offline, no model download); `stub` is the legacy length-based
-  stub (degenerate for ranking, kept for compatibility)
+- `EMBEDDINGS_PROVIDER=openai|local|hash|stub` (recommended: `openai`).
+  `openai` uses text-embedding-3-small by default, overridable via
+  `OPENAI_EMBEDDING_MODEL`; network-hosted, no local torch worker to swap
+  out under memory pressure. `local` uses sentence-transformers
+  (`LOCAL_EMBEDDING_MODEL`, default all-MiniLM-L6-v2); works on a well-fed
+  host, but a memory-tight worker can silently fall back to stub embeddings
+  and collapse retrieval to identical top-k for every query. `hash` is a
+  deterministic hashed bag-of-words used by CI golden-query tests (offline,
+  no model download); `stub` is the legacy length-based stub (degenerate
+  for ranking, kept for compatibility).
+- Switching embedder (different vector dimension) invalidates the store;
+  wipe `VECTORSTORE_PATH` and re-ingest. Pin `RAG_COLLECTION` to a per-model
+  name (e.g. `docs_openai_3_small`) so accidental provider flips do not hit
+  a stale collection.
 - `RAG_MULTI_QUERY_ENABLED=false`, `RAG_MULTI_QUERY_COUNT=3`,
   `RAG_HYDE_ENABLED=false` — deterministic query-expansion flags
   (keyword-scan path)

--- a/scripts/run_langsmith_eval.py
+++ b/scripts/run_langsmith_eval.py
@@ -42,13 +42,18 @@ def stream_architect(question: str, url: str, timeout: float, max_tokens: Option
 
     # Fresh session per example: with backend-agnostic memory, sharing the
     # implicit "default" session would leak conversation context across
-    # dataset examples and contaminate groundedness.
-    session_id = f"eval-{uuid.uuid4().hex[:12]}"
+    # dataset examples and contaminate groundedness. Fresh user_id too:
+    # long-term memory keys on user_id only, so a shared "anonymous" user
+    # accumulates ingested facts across runs and returns them as grounding
+    # context to future eval questions.
+    tag = uuid.uuid4().hex[:12]
+    session_id = f"eval-{tag}"
+    user_id = f"eval-{tag}"
     with httpx.Client(timeout=timeout) as client:
         with client.stream(
             "GET",
             url,
-            params={"question": question, "session_id": session_id},
+            params={"question": question, "session_id": session_id, "user_id": user_id},
             headers={"Accept": "text/event-stream"},
         ) as resp:
             resp.raise_for_status()

--- a/scripts/run_live_eval.py
+++ b/scripts/run_live_eval.py
@@ -44,9 +44,11 @@ def load_prompts(path: str) -> List[str]:
 
 
 async def stream_architect(question: str, url: str, timeout: float = 60.0, llm_model: Optional[str] = None) -> Dict[str, Any]:
-    # Fresh session per example so backend memory cannot leak context
-    # between eval questions (see run_langsmith_eval.py).
-    params = {"question": question, "session_id": f"eval-{uuid.uuid4().hex[:12]}"}
+    # Fresh session + user per example so backend memory (both tiers)
+    # cannot leak context between eval questions. Long-term memory keys on
+    # user_id only, so a shared user accumulates facts across runs.
+    tag = uuid.uuid4().hex[:12]
+    params = {"question": question, "session_id": f"eval-{tag}", "user_id": f"eval-{tag}"}
     if llm_model:
         params["llm_model"] = llm_model
     meta: Dict[str, Any] = {}


### PR DESCRIPTION
Two small changes that came out of tonight's eval work; both make eval numbers actually mean what they say.

## 1. Fresh user_id per eval example

The session_id fix in #27 stopped short-term memory from leaking across eval prompts, but **long-term memory keys on user_id only**. With no user_id sent, every eval landed on the same `anonymous` bucket:

- `memory_long_reads` accumulated 78 stale facts across a 26-prompt run
- `memory_long_writes` fed 113 fresh answers back into the same bucket, poisoning the next run

Both eval harnesses now send `user_id=eval-<uuid>` alongside `session_id`. Verified: 0 long_reads across the next 26-prompt run.

## 2. OpenAI text-embedding-3-small as recommended embedder

Local sentence-transformers work on a well-fed host but on memory-tight WSL2 the model silently falls back to stub embeddings, and retrieval collapses to the same top-3 for every query. Debugged twice tonight; a WSL restart bought one clean run before it happened again. OpenAI embeddings are one HTTP call, no local torch worker to lose.

**Measured lift** (openai-embed-74c04c67 vs docs-overhaul-headings-0d660fad, same 26 prompts):

| metric | local (headings) | openai-3-small |
|---|---|---|
| judge_groundedness | 3.92 | **4.12** |
| judge_correctness | 3.92 | **4.12** |
| judge_completeness | 3.54 | **3.77** |
| judge_actionability | 3.77 | **3.92** |
| keywords_present | 0.94 | **1.00** |
| latency_s | 9.67 | **6.39** |

Every metric up; latency drops 33% because local encode was actually the slower op on this box.

Also updated the code default (`OPENAIEmbeddings` fell through to legacy ada-002), and pinned `RAG_COLLECTION` to a per-model name in the template so a provider flip does not silently hit a stale vector collection.

## Tests

- 181 pass.
- Live over both eval harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)