### PR TITLE
docs: second-pass styling fixes on top of merged PR #32

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -54,26 +54,18 @@ This service is a FastAPI application for AI risk, compliance, and observability
 
 ## Notable endpoints
 
-### GET /healthz
+### GET /healthz — liveness probe
 
-liveness probe
+### GET /metrics — Prometheus metrics (optionally token-protected)
 
-### GET /metrics
-
-Prometheus metrics (optionally token-protected)
-
-### POST /predict
-
-model inference; requires role analyst/admin
+### POST /predict — model inference; requires role analyst/admin
 
 - Request: { features: object, user_id?: string }
 - Rules: features must be a non-empty object with numeric-like values; exact feature set must match training
 - Errors: 400 when features invalid/mismatch or when no model is available
 - Notes: training is required first (see docs/ml.md); the server reorders inputs to the training feature order
 
-### GET /predict/schema
-
-returns expected feature list and model metadata (analyst/admin)
+### GET /predict/schema — returns expected feature list and model metadata (analyst/admin)
 
 - Response: { features: [string], run_id: string, experiment: string }
 - Notes: Artifacts names configurable via MLFLOW_MODEL_ARTIFACT_PATH and MLFLOW_FEATURE_ORDER_ARTIFACT; MLFLOW_MODEL_URI can override model selection; MLFLOW_MODEL_CACHE_TTL enables in-process caching.
@@ -95,9 +87,7 @@ returns expected feature list and model metadata (analyst/admin)
   - memory_short_reads, memory_short_writes, summary_updated, memory_short_pruned
   - memory_long_reads, memory_long_writes, memory_long_pruned
 
-### POST /risk
-
-Risk scoring endpoint (analyst/admin)
+### POST /risk — Risk scoring endpoint (analyst/admin)
 
 - Request: { text: string }
 - Response: { label: "low|medium|high", value: number in [0,1], rationale: string, audit: { ... } }
@@ -110,72 +100,52 @@ Risk scoring endpoint (analyst/admin)
 - Audit enrichment:
   - audit.risk_score_label, audit.risk_score_value, audit.risk_score_method
 
-### POST /policy_navigator
-
-Policy Navigator Agent (analyst/admin)
+### POST /policy_navigator — Policy Navigator Agent (analyst/admin)
 
 - Request: { question: string, max_subqs?: number }
 - Response: { recommendation: string, citations: [{source, snippet, page?}], audit: { steps[] } }
 
-### POST /pii_remediation
-
-PII Remediation Agent (analyst/admin)
+### POST /pii_remediation — PII Remediation Agent (analyst/admin)
 
 - Request: { text: string, return_snippets?: boolean, grounded?: boolean }
 - Response: { remediation: [...], citations?: [...], audit: { pii_entities_count, pii_types } }
 
-### GET /memory/short
-
-list short-term memory for a session (analyst/admin)
+### GET /memory/short — list short-term memory for a session (analyst/admin)
 
 - Params: user_id (required), session_id (required)
 - Response: { turns: [{role, content, timestamp}], summary: string|null, audit: {...} }
 
-### DELETE /memory/short
-
-clear short-term memory for a session (analyst/admin)
+### DELETE /memory/short — clear short-term memory for a session (analyst/admin)
 
 - Params: user_id (required), session_id (required)
 - Response: { cleared: boolean, audit: {...} }
 
-### GET /memory/long
-
-list long-term facts (analyst/admin)
+### GET /memory/long — list long-term facts (analyst/admin)
 
 - Params: user_id (required), q (optional)
 - Response: { facts: [{text, created_at?, metadata?}], audit: {..., memory_long_reads?, memory_long_pruned?} }
 
-### DELETE /memory/long
-
-clear long-term facts for user (analyst/admin)
+### DELETE /memory/long — clear long-term facts for user (analyst/admin)
 
 - Params: user_id (required)
 - Response: { cleared: boolean, audit: {...} }
 
-### GET /memory/long/export
-
-export long-term facts (analyst/admin)
+### GET /memory/long/export — export long-term facts (analyst/admin)
 
 - Params: user_id (required)
 - Response: { facts: [{id, text, created_at, metadata, embedding_present, embedding_dim}], audit: {..., memory_long_reads?, memory_long_pruned?} }
 
-### POST /memory/long/import
-
-import long-term facts (analyst/admin)
+### POST /memory/long/import — import long-term facts (analyst/admin)
 
 - Params: user_id (required)
 - Body: { facts: [{ text: string, metadata?: object }] }
 - Response: { imported: number, audit: {..., memory_long_writes?, memory_long_pruned?} }
 
-### GET /memory/status
-
-memory status (admin only)
+### GET /memory/status — memory status (admin only)
 
 - Response: { config: {...}, short_memory: { sessions: [{user_id, session_id, turns, summary}], db_ok }, long_memory: { users: [{user_id, facts}], store_ok }, counters: { memory_short_pruned_total, memory_long_pruned_total }, audit: {...} }
 
-### POST /research
-
-multi-step research pipeline with auditing; step RBAC applies
+### POST /research — multi-step research pipeline with auditing; step RBAC applies
 
 - Request: { topic: string, steps?: ["search","fetch","summarize","risk_check"], user_id?: string }
 - Response: { findings: [...], sources: [...], steps: [{name,inputs,outputs,latency_ms,hash,timestamp}], audit: {...} }
@@ -183,9 +153,7 @@ multi-step research pipeline with auditing; step RBAC applies
 - Flags: AGENT_LIVE_MODE, AGENT_URL_ALLOWLIST, DENYLIST
 - See docs/agents.md for step details
 
-### POST /think (analyst/admin)
-
-Structured intermediate reasoning ahead of an Architect plan.
+### POST /think — Structured intermediate reasoning ahead of an Architect plan (analyst/admin)
 
 - Request: { request_type: "ThinkRequest"|"ToolResult", ... }
 - Response: planner output plus audit (tokens/cost/latency)
@@ -202,18 +170,13 @@ Structured intermediate reasoning ahead of an Architect plan.
 
 ## Architect
 
-### POST /architect
-
-Structured plan generation; requires `PROJECT_GUIDE_ENABLED=true`.
-
+### POST /architect — Structured plan generation (requires PROJECT_GUIDE_ENABLED=true)
 
 - Request: { question: string (min 3), grounded?: boolean|null, user_id?: string, session_id?: string }
 - Response: { answer: string, citations?: [Citation], suggested_steps?: [string], suggested_env_flags?: [string], audit: {...}, suggest_feature?: bool, feature_request?: object }
 - Flags: PROJECT_GUIDE_ENABLED, LLM_ENABLE_ARCHITECT, DOCS_PATH, RAG flags
 
-### GET /architect/stream
-
-(SSE)
+### GET /architect/stream — (SSE)
 
 - Content-Type: text/event-stream
 - Event contract: see docs/agents.md (Architect Agent)

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,81 +54,128 @@ This service is a FastAPI application for AI risk, compliance, and observability
 
 ## Notable endpoints
 
-- GET /healthz — liveness probe
-- GET /metrics — Prometheus metrics (optionally token-protected)
-- POST /predict — model inference; requires role analyst/admin
-  - Request: { features: object, user_id?: string }
-  - Rules: features must be a non-empty object with numeric-like values; exact feature set must match training
-  - Errors: 400 when features invalid/mismatch or when no model is available
-  - Notes: training is required first (see docs/ml.md); the server reorders inputs to the training feature order
-- GET /predict/schema — returns expected feature list and model metadata (analyst/admin)
-  - Response: { features: [string], run_id: string, experiment: string }
-  - Notes: Artifacts names configurable via MLFLOW_MODEL_ARTIFACT_PATH and MLFLOW_FEATURE_ORDER_ARTIFACT; MLFLOW_MODEL_URI can override model selection; MLFLOW_MODEL_CACHE_TTL enables in-process caching.
-- POST /query
-  - Request: { question: str, grounded?: bool, user_id?: str, session_id?: str, intent?: str }
-  - Response: { answer, citations?, audit }
-  - Notes: session_id enables short-term memory grouping when MEMORY_SHORT_ENABLED=true
-  - Config: ROUTER_ENABLED (intent routing)
-  - Feature flags:
-    - ROUTER_ENABLED: routes intents (qa, pii_detect, risk_score, other) using simple rules
-  - Request fields:
-    - question: string (min 3)
-    - grounded: boolean (default false)
-    - user_id: optional string
-    - intent: optional ("auto"|"qa"|"pii_detect"|"risk_score"|"other"); default "auto"
-  - Audit (when memory flags enabled):
-    - memory_short_reads, memory_short_writes, summary_updated, memory_short_pruned
-    - memory_long_reads, memory_long_writes, memory_long_pruned
-- POST /risk — Risk scoring endpoint (analyst/admin)
-  - Request: { text: string }
-  - Response: { label: "low|medium|high", value: number in [0,1], rationale: string, audit: { ... } }
-  - Feature flags:
-    - RISK_ML_ENABLED (default: false) — when true, uses a deterministic pseudo-ML path
-    - RISK_THRESHOLD (default: 0.6) — classification threshold for ML path
-  - Behavior:
-    - Default is heuristic scoring based on risk keywords; audit.risk_score_method == "heuristic"
-    - When ML is enabled, audit.risk_score_method == "ml" and label/value are derived from the pseudo-ML signal
-  - Audit enrichment:
-    - audit.risk_score_label, audit.risk_score_value, audit.risk_score_method
-- POST /policy_navigator — Policy Navigator Agent (analyst/admin)
-  - Request: { question: string, max_subqs?: number }
-  - Response: { recommendation: string, citations: [{source, snippet, page?}], audit: { steps[] } }
-- POST /pii_remediation — PII Remediation Agent (analyst/admin)
-  - Request: { text: string, return_snippets?: boolean, grounded?: boolean }
-  - Response: { remediation: [...], citations?: [...], audit: { pii_entities_count, pii_types } }
+### GET /healthz
 
-- GET /memory/short — list short-term memory for a session (analyst/admin)
-  - Params: user_id (required), session_id (required)
-  - Response: { turns: [{role, content, timestamp}], summary: string|null, audit: {...} }
-- DELETE /memory/short — clear short-term memory for a session (analyst/admin)
-  - Params: user_id (required), session_id (required)
-  - Response: { cleared: boolean, audit: {...} }
-- GET /memory/long — list long-term facts (analyst/admin)
-  - Params: user_id (required), q (optional)
-  - Response: { facts: [{text, created_at?, metadata?}], audit: {..., memory_long_reads?, memory_long_pruned?} }
-- DELETE /memory/long — clear long-term facts for user (analyst/admin)
-  - Params: user_id (required)
-  - Response: { cleared: boolean, audit: {...} }
-- GET /memory/long/export — export long-term facts (analyst/admin)
-  - Params: user_id (required)
-  - Response: { facts: [{id, text, created_at, metadata, embedding_present, embedding_dim}], audit: {..., memory_long_reads?, memory_long_pruned?} }
-- POST /memory/long/import — import long-term facts (analyst/admin)
-  - Params: user_id (required)
-  - Body: { facts: [{ text: string, metadata?: object }] }
-  - Response: { imported: number, audit: {..., memory_long_writes?, memory_long_pruned?} }
-- GET /memory/status — memory status (admin only)
-  - Response: { config: {...}, short_memory: { sessions: [{user_id, session_id, turns, summary}], db_ok }, long_memory: { users: [{user_id, facts}], store_ok }, counters: { memory_short_pruned_total, memory_long_pruned_total }, audit: {...} }
+liveness probe
 
-- POST /research — multi-step research pipeline with auditing; step RBAC applies
-  - Request: { topic: string, steps?: ["search","fetch","summarize","risk_check"], user_id?: string }
-  - Response: { findings: [...], sources: [...], steps: [{name,inputs,outputs,latency_ms,hash,timestamp}], audit: {...} }
-  - Defaults: steps defaults to [search, fetch, summarize, risk_check]
-  - Flags: AGENT_LIVE_MODE, AGENT_URL_ALLOWLIST, DENYLIST
-  - See docs/agents.md for step details
-- POST /think — think planner: structured intermediate reasoning ahead of an
+### GET /metrics
+
+Prometheus metrics (optionally token-protected)
+
+### POST /predict
+
+model inference; requires role analyst/admin
+- Request: { features: object, user_id?: string }
+- Rules: features must be a non-empty object with numeric-like values; exact feature set must match training
+- Errors: 400 when features invalid/mismatch or when no model is available
+- Notes: training is required first (see docs/ml.md); the server reorders inputs to the training feature order
+
+### GET /predict/schema
+
+returns expected feature list and model metadata (analyst/admin)
+- Response: { features: [string], run_id: string, experiment: string }
+- Notes: Artifacts names configurable via MLFLOW_MODEL_ARTIFACT_PATH and MLFLOW_FEATURE_ORDER_ARTIFACT; MLFLOW_MODEL_URI can override model selection; MLFLOW_MODEL_CACHE_TTL enables in-process caching.
+
+### POST /query
+
+- Request: { question: str, grounded?: bool, user_id?: str, session_id?: str, intent?: str }
+- Response: { answer, citations?, audit }
+- Notes: session_id enables short-term memory grouping when MEMORY_SHORT_ENABLED=true
+- Config: ROUTER_ENABLED (intent routing)
+- Feature flags:
+  - ROUTER_ENABLED: routes intents (qa, pii_detect, risk_score, other) using simple rules
+- Request fields:
+  - question: string (min 3)
+  - grounded: boolean (default false)
+  - user_id: optional string
+  - intent: optional ("auto"|"qa"|"pii_detect"|"risk_score"|"other"); default "auto"
+- Audit (when memory flags enabled):
+  - memory_short_reads, memory_short_writes, summary_updated, memory_short_pruned
+  - memory_long_reads, memory_long_writes, memory_long_pruned
+
+### POST /risk
+
+Risk scoring endpoint (analyst/admin)
+- Request: { text: string }
+- Response: { label: "low|medium|high", value: number in [0,1], rationale: string, audit: { ... } }
+- Feature flags:
+  - RISK_ML_ENABLED (default: false) — when true, uses a deterministic pseudo-ML path
+  - RISK_THRESHOLD (default: 0.6) — classification threshold for ML path
+- Behavior:
+  - Default is heuristic scoring based on risk keywords; audit.risk_score_method == "heuristic"
+  - When ML is enabled, audit.risk_score_method == "ml" and label/value are derived from the pseudo-ML signal
+- Audit enrichment:
+  - audit.risk_score_label, audit.risk_score_value, audit.risk_score_method
+
+### POST /policy_navigator
+
+Policy Navigator Agent (analyst/admin)
+- Request: { question: string, max_subqs?: number }
+- Response: { recommendation: string, citations: [{source, snippet, page?}], audit: { steps[] } }
+
+### POST /pii_remediation
+
+PII Remediation Agent (analyst/admin)
+- Request: { text: string, return_snippets?: boolean, grounded?: boolean }
+- Response: { remediation: [...], citations?: [...], audit: { pii_entities_count, pii_types } }
+
+### GET /memory/short
+
+list short-term memory for a session (analyst/admin)
+- Params: user_id (required), session_id (required)
+- Response: { turns: [{role, content, timestamp}], summary: string|null, audit: {...} }
+
+### DELETE /memory/short
+
+clear short-term memory for a session (analyst/admin)
+- Params: user_id (required), session_id (required)
+- Response: { cleared: boolean, audit: {...} }
+
+### GET /memory/long
+
+list long-term facts (analyst/admin)
+- Params: user_id (required), q (optional)
+- Response: { facts: [{text, created_at?, metadata?}], audit: {..., memory_long_reads?, memory_long_pruned?} }
+
+### DELETE /memory/long
+
+clear long-term facts for user (analyst/admin)
+- Params: user_id (required)
+- Response: { cleared: boolean, audit: {...} }
+
+### GET /memory/long/export
+
+export long-term facts (analyst/admin)
+- Params: user_id (required)
+- Response: { facts: [{id, text, created_at, metadata, embedding_present, embedding_dim}], audit: {..., memory_long_reads?, memory_long_pruned?} }
+
+### POST /memory/long/import
+
+import long-term facts (analyst/admin)
+- Params: user_id (required)
+- Body: { facts: [{ text: string, metadata?: object }] }
+- Response: { imported: number, audit: {..., memory_long_writes?, memory_long_pruned?} }
+
+### GET /memory/status
+
+memory status (admin only)
+- Response: { config: {...}, short_memory: { sessions: [{user_id, session_id, turns, summary}], db_ok }, long_memory: { users: [{user_id, facts}], store_ok }, counters: { memory_short_pruned_total, memory_long_pruned_total }, audit: {...} }
+
+### POST /research
+
+multi-step research pipeline with auditing; step RBAC applies
+- Request: { topic: string, steps?: ["search","fetch","summarize","risk_check"], user_id?: string }
+- Response: { findings: [...], sources: [...], steps: [{name,inputs,outputs,latency_ms,hash,timestamp}], audit: {...} }
+- Defaults: steps defaults to [search, fetch, summarize, risk_check]
+- Flags: AGENT_LIVE_MODE, AGENT_URL_ALLOWLIST, DENYLIST
+- See docs/agents.md for step details
+
+### POST /think
+
+think planner: structured intermediate reasoning ahead of an
   Architect plan (analyst/admin)
-  - Request: { request_type: "ThinkRequest"|"ToolResult", ... }
-  - Response: planner output plus audit (tokens/cost/latency)
+- Request: { request_type: "ThinkRequest"|"ToolResult", ... }
+- Response: planner output plus audit (tokens/cost/latency)
 
 ## Router Agent
 
@@ -142,14 +189,21 @@ This service is a FastAPI application for AI risk, compliance, and observability
 
 ## Architect
 
-- POST /architect (requires PROJECT_GUIDE_ENABLED=true)
-  - Request: { question: string (min 3), grounded?: boolean|null, user_id?: string, session_id?: string }
-  - Response: { answer: string, citations?: [Citation], suggested_steps?: [string], suggested_env_flags?: [string], audit: {...}, suggest_feature?: bool, feature_request?: object }
-  - Flags: PROJECT_GUIDE_ENABLED, LLM_ENABLE_ARCHITECT, DOCS_PATH, RAG flags
-- GET /architect/stream (SSE)
-  - Content-Type: text/event-stream
-  - Event contract: see docs/agents.md (Architect Agent)
-- GET /architect/ui
-  - Content-Type: text/html
+### POST /architect
+
+(requires PROJECT_GUIDE_ENABLED=true)
+- Request: { question: string (min 3), grounded?: boolean|null, user_id?: string, session_id?: string }
+- Response: { answer: string, citations?: [Citation], suggested_steps?: [string], suggested_env_flags?: [string], audit: {...}, suggest_feature?: bool, feature_request?: object }
+- Flags: PROJECT_GUIDE_ENABLED, LLM_ENABLE_ARCHITECT, DOCS_PATH, RAG flags
+
+### GET /architect/stream
+
+(SSE)
+- Content-Type: text/event-stream
+- Event contract: see docs/agents.md (Architect Agent)
+
+### GET /architect/ui
+
+- Content-Type: text/html
 
 See docs/agents.md for details on SSE events and flags.

--- a/docs/api.md
+++ b/docs/api.md
@@ -65,6 +65,7 @@ Prometheus metrics (optionally token-protected)
 ### POST /predict
 
 model inference; requires role analyst/admin
+
 - Request: { features: object, user_id?: string }
 - Rules: features must be a non-empty object with numeric-like values; exact feature set must match training
 - Errors: 400 when features invalid/mismatch or when no model is available
@@ -73,6 +74,7 @@ model inference; requires role analyst/admin
 ### GET /predict/schema
 
 returns expected feature list and model metadata (analyst/admin)
+
 - Response: { features: [string], run_id: string, experiment: string }
 - Notes: Artifacts names configurable via MLFLOW_MODEL_ARTIFACT_PATH and MLFLOW_FEATURE_ORDER_ARTIFACT; MLFLOW_MODEL_URI can override model selection; MLFLOW_MODEL_CACHE_TTL enables in-process caching.
 
@@ -96,6 +98,7 @@ returns expected feature list and model metadata (analyst/admin)
 ### POST /risk
 
 Risk scoring endpoint (analyst/admin)
+
 - Request: { text: string }
 - Response: { label: "low|medium|high", value: number in [0,1], rationale: string, audit: { ... } }
 - Feature flags:
@@ -110,48 +113,56 @@ Risk scoring endpoint (analyst/admin)
 ### POST /policy_navigator
 
 Policy Navigator Agent (analyst/admin)
+
 - Request: { question: string, max_subqs?: number }
 - Response: { recommendation: string, citations: [{source, snippet, page?}], audit: { steps[] } }
 
 ### POST /pii_remediation
 
 PII Remediation Agent (analyst/admin)
+
 - Request: { text: string, return_snippets?: boolean, grounded?: boolean }
 - Response: { remediation: [...], citations?: [...], audit: { pii_entities_count, pii_types } }
 
 ### GET /memory/short
 
 list short-term memory for a session (analyst/admin)
+
 - Params: user_id (required), session_id (required)
 - Response: { turns: [{role, content, timestamp}], summary: string|null, audit: {...} }
 
 ### DELETE /memory/short
 
 clear short-term memory for a session (analyst/admin)
+
 - Params: user_id (required), session_id (required)
 - Response: { cleared: boolean, audit: {...} }
 
 ### GET /memory/long
 
 list long-term facts (analyst/admin)
+
 - Params: user_id (required), q (optional)
 - Response: { facts: [{text, created_at?, metadata?}], audit: {..., memory_long_reads?, memory_long_pruned?} }
 
 ### DELETE /memory/long
 
 clear long-term facts for user (analyst/admin)
+
 - Params: user_id (required)
 - Response: { cleared: boolean, audit: {...} }
 
 ### GET /memory/long/export
 
 export long-term facts (analyst/admin)
+
 - Params: user_id (required)
 - Response: { facts: [{id, text, created_at, metadata, embedding_present, embedding_dim}], audit: {..., memory_long_reads?, memory_long_pruned?} }
 
 ### POST /memory/long/import
 
 import long-term facts (analyst/admin)
+
 - Params: user_id (required)
 - Body: { facts: [{ text: string, metadata?: object }] }
 - Response: { imported: number, audit: {..., memory_long_writes?, memory_long_pruned?} }
@@ -159,21 +170,23 @@ import long-term facts (analyst/admin)
 ### GET /memory/status
 
 memory status (admin only)
+
 - Response: { config: {...}, short_memory: { sessions: [{user_id, session_id, turns, summary}], db_ok }, long_memory: { users: [{user_id, facts}], store_ok }, counters: { memory_short_pruned_total, memory_long_pruned_total }, audit: {...} }
 
 ### POST /research
 
 multi-step research pipeline with auditing; step RBAC applies
+
 - Request: { topic: string, steps?: ["search","fetch","summarize","risk_check"], user_id?: string }
 - Response: { findings: [...], sources: [...], steps: [{name,inputs,outputs,latency_ms,hash,timestamp}], audit: {...} }
 - Defaults: steps defaults to [search, fetch, summarize, risk_check]
 - Flags: AGENT_LIVE_MODE, AGENT_URL_ALLOWLIST, DENYLIST
 - See docs/agents.md for step details
 
-### POST /think
+### POST /think (analyst/admin)
 
-think planner: structured intermediate reasoning ahead of an
-  Architect plan (analyst/admin)
+Structured intermediate reasoning ahead of an Architect plan.
+
 - Request: { request_type: "ThinkRequest"|"ToolResult", ... }
 - Response: planner output plus audit (tokens/cost/latency)
 
@@ -191,7 +204,9 @@ think planner: structured intermediate reasoning ahead of an
 
 ### POST /architect
 
-(requires PROJECT_GUIDE_ENABLED=true)
+Structured plan generation; requires `PROJECT_GUIDE_ENABLED=true`.
+
+
 - Request: { question: string (min 3), grounded?: boolean|null, user_id?: string, session_id?: string }
 - Response: { answer: string, citations?: [Citation], suggested_steps?: [string], suggested_env_flags?: [string], audit: {...}, suggest_feature?: bool, feature_request?: object }
 - Flags: PROJECT_GUIDE_ENABLED, LLM_ENABLE_ARCHITECT, DOCS_PATH, RAG flags
@@ -199,6 +214,7 @@ think planner: structured intermediate reasoning ahead of an
 ### GET /architect/stream
 
 (SSE)
+
 - Content-Type: text/event-stream
 - Event contract: see docs/agents.md (Architect Agent)
 

--- a/docs/manual_e2e_test.md
+++ b/docs/manual_e2e_test.md
@@ -187,7 +187,8 @@ curl -sS -X POST localhost:8000/pii \
 - pii.types_present contains email and phone
 - masked previews in entities
 
-Optional locales
+### Optional locales
+
 ```bash
 export PII_LOCALES="US,UK,CA"
 ```

--- a/docs/worklog/2025-10-18-capabilities-roadmap.md
+++ b/docs/worklog/2025-10-18-capabilities-roadmap.md
@@ -10,7 +10,8 @@
 - For each capability: define value, ports/interfaces, options, phased plan, success metrics, dependencies, fallbacks, and ADR triggers.
 - Keep domain-specific examples generic (e.g., "time-series signals" or "sequential decision-making").
 
-1) Protocols and interop
+## 1) Protocols and interop
+
 - Value: low-latency, language-agnostic clients; interactive sessions.
 - Ports/Interfaces: gRPC services for Query/Predict/Architect (unary + stream), WebSockets for bi-directional chat; interceptors for auth/trace.
 - Options: grpcio + grpc-gateway; FastAPI WebSockets; SSE remains for simplicity.
@@ -21,7 +22,8 @@
 - Success: p95 latency under target; feature parity with REST; robust cancellation.
 - ADRs: gRPC service design; WebSockets event model.
 
-2) Feature store and data quality
+## 2) Feature store and data quality
+
 - Value: consistent online/offline features; reduce training-serving skew.
 - Ports: FeatureStorePort; QualityCheckPort.
 - Options: Feast (online/offline), sqlite/parquet default; Great Expectations or Soda.
@@ -32,7 +34,8 @@
 - Success: feature hit ratio > 99% in tests; freshness SLO; expectation pass rate.
 - ADRs: feature store selection; expectation policy (block vs warn).
 
-3) Vector backends and hybrid search
+## 3) Vector backends and hybrid search
+
 - Value: scalable retrieval; portability.
 - Ports: VectorStorePort; EmbeddingsPort (exists conceptually).
 - Options: FAISS/Chroma default; pgvector, Qdrant, Weaviate, Milvus; hybrid BM25 + dense; rerankers.
@@ -43,7 +46,8 @@
 - Success: retrieval quality on golden queries; ingestion idempotency; latency SLOs.
 - ADRs: backend choices; migration strategy.
 
-4) Model adaptation and serving performance
+## 4) Model adaptation and serving performance
+
 - Value: align models with domain; improve latency/cost.
 - Ports: AdapterLoaderPort; ServingPort.
 - Options: PEFT/LoRA/QLoRA; vLLM/TensorRT-LLM; OpenAI/Azure/AWS endpoints.
@@ -54,7 +58,8 @@
 - Success: quality uplift vs baseline; latency/cost reductions.
 - ADRs: adapter loading strategy; eval/rollback policy.
 
-5) Sequential decision-making (generic)
+## 5) Sequential decision-making (generic)
+
 - Value: adapt retrieval/tool choices and resources under uncertainty.
 - Ports: PolicyPort; FeedbackPort.
 - Options: contextual bandits for reranking/query reformulation/tool selection; offline evaluation first; online shadow.
@@ -65,14 +70,16 @@
 - Success: improved metrics (citation correctness, cost, latency) on A/B; safe rollback.
 - ADRs: policy selection scope; metrics and guardrails.
 
-6) Ingestion (reference)
+## 6) Ingestion (reference)
+
 - Value: scalable streaming/batch; deterministic CI.
 - Ports: SourcePort, StreamBusPort, ComputePort, FeatureStorePort, VectorStorePort, MetadataStorePort, OrchestratorPort (see ingestion_pipelines.md).
 - Phases: per ingestion_pipelines.md (P1 docs → P4 optional integrations).
 - Success: idempotent upserts; measurable lag and error budgets.
 - ADRs: ingestion architecture (ADR 0002 exists), adapters as needed.
 
-7) Observability and tracing
+## 7) Observability and tracing
+
 - Value: diagnose latency/cost/hallucination/drift fast; correlate across services.
 - Ports: TracePort; Metrics registry; Log sink.
 - Options: OpenTelemetry; LangSmith; Prometheus/Grafana (exists); structured logs (exists).
@@ -83,7 +90,8 @@
 - Success: end-to-end trace coverage > 80% in staging; low overhead.
 - ADRs: tracing backend and sampling policy.
 
-8) Security and governance
+## 8) Security and governance
+
 - Value: safe multi-tenant operation and compliance.
 - Ports: AuthZPort (OPA/Cerbos), SecretsPort (KMS/Vault), RetentionPort.
 - Options: OPA/Cerbos; Vault/KMS; encrypted vector stores; DP options.
@@ -94,7 +102,8 @@
 - Success: policy coverage; least privilege; retention verified in tests.
 - ADRs: ABAC engine; data retention model.
 
-9) Evaluation and feedback
+## 9) Evaluation and feedback
+
 - Value: measurable quality and safe iteration.
 - Ports: EvalPort; FeedbackPort.
 - Options: golden sets; citation correctness; hallucination metrics; Argilla/Label Studio.
@@ -105,7 +114,8 @@
 - Success: CI eval gates; online improvements without regressions.
 - ADRs: metric definitions; promotion criteria.
 
-10) Deployment and DevX
+## 10) Deployment and DevX
+
 - Value: reproducible deployments and smooth developer experience.
 - Ports: CLI; IaC; CodegenPort.
 - Options: Helm/TF; OpenAPI/proto codegen; Make targets; local sandbox.

--- a/docs/worklog/2025-10-18-capabilities-roadmap.md
+++ b/docs/worklog/2025-10-18-capabilities-roadmap.md
@@ -1,16 +1,18 @@
 # Capabilities Roadmap (Planning)
 
-Purpose and principles
-- Provide a vendor‑neutral, actionable plan for advanced capabilities.
-- Principles: deterministic by default (CI offline), ports‑and‑adapters, privacy‑first, observability built‑in, graceful fallbacks.
+## Purpose and principles
 
-How to use this roadmap
+- Provide a vendor-neutral, actionable plan for advanced capabilities.
+- Principles: deterministic by default (CI offline), ports-and-adapters, privacy-first, observability built-in, graceful fallbacks.
+
+## How to use this roadmap
+
 - For each capability: define value, ports/interfaces, options, phased plan, success metrics, dependencies, fallbacks, and ADR triggers.
-- Keep domain‑specific examples generic (e.g., “time‑series signals” or “sequential decision‑making”).
+- Keep domain-specific examples generic (e.g., "time-series signals" or "sequential decision-making").
 
 1) Protocols and interop
-- Value: low‑latency, language‑agnostic clients; interactive sessions.
-- Ports/Interfaces: gRPC services for Query/Predict/Architect (unary + stream), WebSockets for bi‑directional chat; interceptors for auth/trace.
+- Value: low-latency, language-agnostic clients; interactive sessions.
+- Ports/Interfaces: gRPC services for Query/Predict/Architect (unary + stream), WebSockets for bi-directional chat; interceptors for auth/trace.
 - Options: grpcio + grpc-gateway; FastAPI WebSockets; SSE remains for simplicity.
 - Phases:
   - P0: proto contracts; SSE contract documented (exists), WS/grpc design.
@@ -20,12 +22,12 @@ How to use this roadmap
 - ADRs: gRPC service design; WebSockets event model.
 
 2) Feature store and data quality
-- Value: consistent online/offline features; reduce training‑serving skew.
+- Value: consistent online/offline features; reduce training-serving skew.
 - Ports: FeatureStorePort; QualityCheckPort.
 - Options: Feast (online/offline), sqlite/parquet default; Great Expectations or Soda.
 - Phases:
   - P0: design doc + schemas (FeatureRow) (ingestion_pipelines.md covers); minimal local store.
-  - P1: batch writer/reader, predict‑time lookup; basic expectations.
+  - P1: batch writer/reader, predict-time lookup; basic expectations.
   - P2: online store adapter (Redis/sql); freshness/TTL; skew checks.
 - Success: feature hit ratio > 99% in tests; freshness SLO; expectation pass rate.
 - ADRs: feature store selection; expectation policy (block vs warn).
@@ -44,15 +46,15 @@ How to use this roadmap
 4) Model adaptation and serving performance
 - Value: align models with domain; improve latency/cost.
 - Ports: AdapterLoaderPort; ServingPort.
-- Options: PEFT/LoRA/QLoRA; vLLM/TensorRT‑LLM; OpenAI/Azure/AWS endpoints.
+- Options: PEFT/LoRA/QLoRA; vLLM/TensorRT-LLM; OpenAI/Azure/AWS endpoints.
 - Phases:
   - P0: adapter loading design, registry link; prompt registry remains default.
   - P1: PEFT adapter load for local HF model; eval gates; rollback.
-  - P2: acceleration backend integration (vLLM/TensorRT‑LLM).
+  - P2: acceleration backend integration (vLLM/TensorRT-LLM).
 - Success: quality uplift vs baseline; latency/cost reductions.
 - ADRs: adapter loading strategy; eval/rollback policy.
 
-5) Sequential decision‑making (generic)
+5) Sequential decision-making (generic)
 - Value: adapt retrieval/tool choices and resources under uncertainty.
 - Ports: PolicyPort; FeedbackPort.
 - Options: contextual bandits for reranking/query reformulation/tool selection; offline evaluation first; online shadow.
@@ -78,11 +80,11 @@ How to use this roadmap
   - P0: trace design with context propagation; sampling plan.
   - P1: basic traces for LLM calls and RAG; link request_id.
   - P2: spans across gRPC/WebSockets and ingestion stages.
-- Success: end‑to‑end trace coverage > 80% in staging; low overhead.
+- Success: end-to-end trace coverage > 80% in staging; low overhead.
 - ADRs: tracing backend and sampling policy.
 
 8) Security and governance
-- Value: safe multi‑tenant operation and compliance.
+- Value: safe multi-tenant operation and compliance.
 - Ports: AuthZPort (OPA/Cerbos), SecretsPort (KMS/Vault), RetentionPort.
 - Options: OPA/Cerbos; Vault/KMS; encrypted vector stores; DP options.
 - Phases:
@@ -111,14 +113,15 @@ How to use this roadmap
   - P0: CLI plan and minimal commands; proto/OpenAPI codegen guidance.
   - P1: Helm chart and TF modules; CI/CD pipelines for models/data/prompts.
   - P2: chaos/resilience testing playbooks.
-- Success: time‑to‑deploy and MTTR reductions; developer onboarding speed.
+- Success: time-to-deploy and MTTR reductions; developer onboarding speed.
 - ADRs: infra stack choices; codegen tooling.
 
 Planning board (draft)
 - P0 (docs/design): 1,2,3,4,5,6,7,8,9,10
 - P1 (minimal adapters/POCs): 1(gRPC/WS), 2(local feature store + expectations), 3(FAISS/Chroma), 4(adapter load), 6(local batch/stream scripts), 7(traces for LLM/RAG)
-- P2 (scale/backends): 1(gateway, metadata), 2(online store), 3(pgvector/Qdrant + rerank), 4(vLLM/TensorRT‑LLM), 6(bus adapters + DLQ), 7(distributed traces)
+- P2 (scale/backends): 1(gateway, metadata), 2(online store), 3(pgvector/Qdrant + rerank), 4(vLLM/TensorRT-LLM), 6(bus adapters + DLQ), 7(distributed traces)
 
-Notes
-- Keep domain‑specific RL or finance‑related examples out of public docs; use generic terms like “sequential decision‑making.”
+## Notes
+
+- Keep domain-specific RL or finance-related examples out of public docs; use generic terms like "sequential decision-making."
 - Raise ADRs per capability when design choices solidify.


### PR DESCRIPTION
PR #32 was merged before these three follow-up commits landed on the branch. Bundling them into a new PR.

## Commits

1. **api.md endpoint H3 promotion** — 20 endpoint bullets ('- POST /query — ...') under 'Notable endpoints' converted to '### METHOD /path' H3s. manual_e2e_test 'Optional locales' promoted to '###'. capabilities-roadmap.md three pseudo-headings promoted; non-breaking hyphens normalized.
2. **Second-pass styling** — api.md: blank line between endpoint description sentence and its bullet list; POST /think orphan indent cleaned; POST /architect bare parens promoted to a real sentence. capabilities-roadmap.md: 10 numbered pseudo-headings ('1) Protocols and interop' … '10) Deployment and DevX') promoted to '## N)'.
3. **Endpoint description folded into H3** — per your suggestion, '### POST /risk — Risk scoring endpoint (analyst/admin)' reads better than an H3 with a separate description paragraph. 17 endpoints folded; POST /query stays bare since it had no leading description.

## Tests

181 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)