### PR TITLE
chore: revamp Makefile with self-documenting grouped help (backlog item 7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,17 +4,21 @@ Guidance for coding agents working in this repo.
 
 ## Commands
 
+`make` (or `make help`) prints every target, self-documented and grouped
+(Setup / Test & Lint / Run / Data / Eval / Docker). Highlights:
+
 - `make venv && make install` — setup (Python 3.11+, installs `-e .`)
 - `make test` — full suite; offline by design (stub LLM fixture in conftest).
   CI enforces `--cov=app --cov=scripts --cov-fail-under=75`.
 - `make serve` — uvicorn on :8000
 - `make ingest` — build the Chroma store from DOCS_PATH (needed before
   `RAG_BACKEND=vector` does anything)
-- `make dev-up` / `make dev-down` — observability stack (Prometheus :9090,
-  Grafana :3001)
+- `make dev-up` / `make dev-down` — observability stack, base + dev override
+  (Prometheus :9090, Grafana :3001). `make prod-up` runs base only (no override).
 - Eval runs (BILLED OpenAI + LangSmith calls, never run casually):
-  `python scripts/run_langsmith_eval.py --experiment-prefix <name>`;
-  smoke variant: `--limit 3 --no-judges`. Long runs: use nohup (the harness
+  `make eval PREFIX=<name>` (wraps `scripts/run_langsmith_eval.py`);
+  free smoke: `make eval-smoke`. Also `make eval-dataset` (sync golden set,
+  `DRYRUN=1` to preview) and `make eval-grid`. Long runs: use nohup (the harness
   streams each example through the live server).
 
 ## Architecture in one paragraph

--- a/Makefile
+++ b/Makefile
@@ -1,68 +1,94 @@
-# Simple DX Makefile for ai-architect
-.PHONY: help venv install test serve lint ingest sweep freeze export-openapi dev-up dev-down prod-up prod-down logs
+# DX Makefile for ai-architect.
+# Targets are self-documenting: a `## ...` comment after a target shows up in
+# `make help`, and `##@ ...` lines are group headers. Run `make` or `make help`.
+.PHONY: help venv install test lint serve ingest sweep freeze export-openapi \
+        eval eval-smoke eval-dataset eval-grid eval-live \
+        dev-up dev-down prod-up prod-down logs test-docker
 
-help:
-	@echo "Targets: venv, install, test, serve, lint, ingest, sweep, freeze, export-openapi, dev-up, dev-down, prod-up, prod-down, logs"
+.DEFAULT_GOAL := help
 
-venv:
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage: make \033[36m<target>\033[0m\n"} \
+		/^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2 } \
+		/^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+
+##@ Setup
+venv: ## Create .venv (Python 3.11) and install the package editable
 	@command -v python3.11 >/dev/null 2>&1 || { echo "python3.11 is required but not installed. Please install Python 3.11 (e.g., via pyenv or your package manager)." >&2; exit 1; }
 	python3.11 -m venv .venv
 	. .venv/bin/activate && pip install -U pip setuptools wheel
 	. .venv/bin/activate && pip install -e .
 
-install:
+install: ## Reinstall the package into an existing .venv
 	. .venv/bin/activate && pip install -e .
 
-test:
+##@ Test & Lint
+test: ## Run the full offline test suite (stub LLM, no billed calls)
 	. .venv/bin/activate && pytest -q
 
-serve:
-	. .venv/bin/activate && uvicorn app.main:app --reload
-
-lint:
+lint: ## Ruff check (auto-installs ruff if missing)
 	. .venv/bin/activate && ruff --version >/dev/null 2>&1 || pip install ruff
 	. .venv/bin/activate && ruff check . || true
 
-ingest:
+##@ Run
+serve: ## Run the uvicorn dev server on :8000 (auto-reload)
+	. .venv/bin/activate && uvicorn app.main:app --reload
+
+##@ Data
+ingest: ## Build the Chroma vector store from DOCS_PATH (needed for RAG_BACKEND=vector)
 	. .venv/bin/activate && python scripts/ingest_docs.py
 
-sweep:
+sweep: ## Run the audit-store retention sweep
 	. .venv/bin/activate && python scripts/sweep_retention.py
 
-freeze:
+freeze: ## Freeze the current venv into requirements.txt
 	. .venv/bin/activate && pip freeze > requirements.txt
 
-export-openapi:
+export-openapi: ## Write the OpenAPI schema to disk
 	. .venv/bin/activate && python scripts/export_openapi.py
 
-# Docker helpers
+##@ Eval  (BILLED OpenAI + LangSmith calls — never run casually; eval-smoke is free)
+PREFIX ?= architect-eval
+LIMIT ?= 0
 
-dev-up:
-	docker compose up --build -d
+eval: ## LangSmith eval on the golden dataset (vars: PREFIX, LIMIT, NOJUDGES=1)
+	. .venv/bin/activate && python scripts/run_langsmith_eval.py --experiment-prefix $(PREFIX) --limit $(LIMIT) $(if $(NOJUDGES),--no-judges,)
 
-dev-down:
-	docker compose down
+eval-smoke: ## Fast free smoke: 3 examples, code evaluators only
+	. .venv/bin/activate && python scripts/run_langsmith_eval.py --experiment-prefix smoke --limit 3 --no-judges
 
-prod-up:
-	docker compose -f docker-compose.yml up --build -d
+eval-dataset: ## Sync the golden dataset to LangSmith (DRYRUN=1 to preview)
+	. .venv/bin/activate && python scripts/build_langsmith_dataset.py $(if $(DRYRUN),--dry-run,)
 
-prod-down:
-	docker compose -f docker-compose.yml down
+eval-grid: ## Run the backend/token experiment grid (CELLS="langgraph-2048 ...")
+	. .venv/bin/activate && python scripts/run_experiment_grid.py $(if $(CELLS),--cells $(CELLS),)
 
-logs:
-	docker compose logs -f --tail=200
-
-test-docker:
-	docker compose run --rm api /bin/sh -lc ". /opt/venv/bin/activate || true; [ -d /opt/venv ] || python -m venv /opt/venv; . /opt/venv/bin/activate; pip install -e .; pytest -q"
-
-# Live eval
+# Legacy deterministic live-eval harness (kept for offline shape checks).
 EVAL_FILE ?= eval/architect_prompts.jsonl
 EVAL_LIMIT ?= 0
 SUMMARY_MIN ?= 40
 STEPS_MIN ?= 2
 STEP_CHARS ?= 20
-
 LLM_MODEL ?=
 
-eval-live:
+eval-live: ## Legacy offline live-eval (deterministic shape checks; vars: EVAL_FILE, EVAL_LIMIT)
 	. .venv/bin/activate || true; python scripts/run_live_eval.py --file $(EVAL_FILE) --limit $(EVAL_LIMIT) --summary-min $(SUMMARY_MIN) --steps-min $(STEPS_MIN) --step-chars $(STEP_CHARS) $(if $(LLM_MODEL),--llm-model $(LLM_MODEL),)
+
+##@ Docker  (dev-up = base + docker-compose.override.yml; prod-up = base only)
+dev-up: ## Start the stack with the dev override merged
+	docker compose up --build -d
+
+dev-down: ## Stop the dev stack
+	docker compose down
+
+prod-up: ## Start the stack from docker-compose.yml only (no override)
+	docker compose -f docker-compose.yml up --build -d
+
+prod-down: ## Stop the base-only stack
+	docker compose -f docker-compose.yml down
+
+logs: ## Tail the compose logs (last 200 lines, follow)
+	docker compose logs -f --tail=200
+
+test-docker: ## Run the test suite inside the api container
+	docker compose run --rm api /bin/sh -lc ". /opt/venv/bin/activate || true; [ -d /opt/venv ] || python -m venv /opt/venv; . /opt/venv/bin/activate; pip install -e .; pytest -q"

--- a/docs/worklog/2026-07-06-approach-makefile-revamp.md
+++ b/docs/worklog/2026-07-06-approach-makefile-revamp.md
@@ -1,0 +1,58 @@
+# Approach: Makefile revamp (backlog item 7)
+
+Status: APPROVED (greenlit to start 2026-07-06; item 6 deferred as an epic)
+Relates to: docs/worklog/2026-07-04-docs-knowledge-backlog.md item 7.
+
+## Goal
+
+The Makefile grew target-by-target; `make help` is a single hardcoded echo
+line that already drifts from the real targets (it omits `test-docker` and
+`eval-live`). Make it self-documenting and grouped, and audit for
+dead/duplicated targets while in there. Eval-neutral chore.
+
+## Audit findings (pre-work)
+
+- **`help` is stale and manual.** Lists 15 targets by hand; misses
+  `test-docker` and `eval-live`. Any new target silently falls off.
+- **`dev-up` vs `prod-up` are NOT duplicates.** `docker-compose.override.yml`
+  exists, so `docker compose up` (dev-up) merges base+override while
+  `docker compose -f docker-compose.yml up` (prod-up) loads base only. Real
+  distinction — keep both, but document it so it isn't mistaken for dead code.
+- **No dead targets.** All referenced scripts exist
+  (ingest_docs / sweep_retention / export_openapi / run_live_eval).
+- **Under-exposed scripts.** `run_langsmith_eval.py`,
+  `build_langsmith_dataset.py`, `run_experiment_grid.py` are the current eval
+  surface but have no targets; only the legacy `run_live_eval.py` does. CLAUDE.md
+  already tells people to call `python scripts/run_langsmith_eval.py ...` by hand.
+- **No docs build system** (no mkdocs/sphinx) — docs are plain markdown for the
+  RAG corpus, so a "docs" group means the data/RAG targets (ingest,
+  export-openapi), not a site build.
+
+## Proposed change
+
+**Self-documenting help.** Standard `##`-annotation + `##@` group-header awk
+pattern. `.DEFAULT_GOAL := help`. Each target documents itself inline; `make`
+or `make help` prints grouped, aligned output. New targets self-register.
+
+**Groups:** Setup / Test & Lint / Run / Data / Eval / Docker.
+
+**New eval targets** wrapping the current scripts (all BILLED except smoke):
+- `eval` — `run_langsmith_eval.py` (vars: `PREFIX`, `LIMIT`, `NOJUDGES=1`)
+- `eval-smoke` — 3 examples, `--no-judges` (free/fast)
+- `eval-dataset` — `build_langsmith_dataset.py` (`DRYRUN=1` to preview)
+- `eval-grid` — `run_experiment_grid.py` (`CELLS="..."`)
+- `eval-live` — kept as-is (legacy deterministic harness, its own vars)
+
+**Out of scope (deferred to item 8):** no docker-compose edits, no port/service/
+dashboard changes. This PR only touches the Makefile and the CLAUDE.md commands
+list that mirrors it. Compose ownership stays with the item-8 ops discussion.
+
+## Verification
+
+- `make help` renders grouped and includes every target (grep every
+  `^[a-z].*:` target appears in help output).
+- `make -n <target>` dry-runs unchanged for existing targets (venv, install,
+  test, serve, lint, ingest, sweep, freeze, export-openapi, dev-*, prod-*,
+  logs, test-docker, eval-live) — command bodies must be byte-identical.
+- CLAUDE.md Commands section updated to match (no invented targets).
+- Eval-neutral: no app/eval code touched, so no eval re-run required.


### PR DESCRIPTION
Backlog item 7. Eval-neutral chore.

## What
- **Self-documenting `make help`** — replaces the hardcoded echo line (which had already drifted, omitting `test-docker` and `eval-live`) with an awk-based help that groups targets and auto-registers new ones. `make` now defaults to `help`.
- **Groups:** Setup / Test & Lint / Run / Data / Eval / Docker.
- **New eval targets** wrapping the current LangSmith scripts: `eval` (vars `PREFIX`/`LIMIT`/`NOJUDGES`), `eval-smoke` (free), `eval-dataset` (`DRYRUN=1`), `eval-grid`. Legacy `eval-live` kept as-is.
- **CLAUDE.md** Commands section synced to match.

## Audit notes
- `dev-up` (base + `docker-compose.override.yml`) vs `prod-up` (base only, explicit `-f`) are **not** duplicates — documented so it reads as intentional.
- No dead targets; all referenced scripts exist.

## Out of scope
No docker-compose / port / dashboard changes — the ops surface is designed once under **item 8**.

## Verification
- `make help` renders grouped; all 20 targets present.
- Command bodies for every preserved target are **byte-identical** to the old Makefile (verified by diff).
- No app/eval code touched → no eval re-run needed.

Approach doc: `docs/worklog/2026-07-06-approach-makefile-revamp.md`